### PR TITLE
Fix Patcher, remove hotfix

### DIFF
--- a/Gaijinizer patch/Enemies.txt
+++ b/Gaijinizer patch/Enemies.txt
@@ -439,7 +439,7 @@ One of the familiars that serve Hectate.
 It is an evil spirit that appears in the form of
 a black haired hound. Barghests are said to have
 been symbols of death, appearing at the time of
-death with a howl to announce someone's passing.>#Ron
+death with a howl to announce someone's passing.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -462,7 +462,7 @@ unafraid of humans. In fact, possessing an
 unusually strong lust and inquisitiveness, they
 come across more as friendly dogs than anything
 else. However, she is driven merely by her
-instinct to mate.>#Ron
+instinct to mate.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -482,7 +482,7 @@ just sex appeal. Their texture and softness are
 highly specialized to aid in milking. Their touch
 is even more enticing then their appearance, and
 once someone is in them, escaping them is much
-harder.>#Ron
+harder.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -503,7 +503,7 @@ and vagina. If you're licked or are being raped by
 her, you will become charmed, quickly breaking your
 spirit and resistance.. And your spirit will
 gradually be undermined. This magic is enough to even
-break the will of those who strongly love another.>#Ron
+break the will of those who strongly love another.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -522,7 +522,7 @@ Barghests are generally solitary, and rarely form
 packs. But as there was no sign of humans inside
 the shelter, they began to form competing packs to
 hunt their prey. If caught by one, there is almost
-no hope of escape.>#Ron
+no hope of escape.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -552,7 +552,7 @@ someone is male or female. In other words, what
 she'sreally interested in is the person themselves.
 She may seem in all respects like a nice dog, but
 don't forget, she's no more than a "Girl Demon"
-who can't disobey her instincts.>#Ron
+who can't disobey her instincts.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -578,7 +578,7 @@ One of the familiars that serve Hectate.
 Their duty is to illuminate the gloomy underworld
 for their goddess. For that reason, they're said
 to fuse with the souls of sinners who've fallen
-into the underworld so they can keep it illuminated.>#Ron
+into the underworld so they can keep it illuminated.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -592,7 +592,7 @@ a special mucus from her petals. Like pollen, it
 emits a special seductive smell that bewitches her
 opponent. When she has her opponent bound, this
 mucus acts as a slimy sexual fluid intended
-to break their resistance.>#Ron
+to break their resistance.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -612,7 +612,7 @@ of soft fibres that can efficiently absorb semen
 ejaculated on her feet. In addition, because of
 the unique sensation of her skin, there are few
 males able to stop themselves from falling to
-their knees before her.>#RonIffy
+their knees before her.#RonIffy
 > END STRING
 
 > BEGIN STRING
@@ -632,7 +632,7 @@ aphrodisiac effect. Its power is enough to shake
 one's will even just looking at it. The candy that
 lampas make from their hardened nectar are called
 "Lampas Drops". It's prized in the demon realm for
-its anti-charm protection.>#Ron
+its anti-charm protection.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -645,7 +645,7 @@ When Lampas petals cover their prey, they close
 to tightly envelop their victim. In addition to
 preventing their prey from escaping, it's
 believed that this also provides a stable footing
-for her ivy to root.>#Ron
+for her ivy to root.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -659,7 +659,7 @@ The Lampas that came to "My Room" believed her
 reason for living was to light her tail. She now
 fully accepts that she'll never be able to light
 it. It's a massive act of selflessness for her to
-have come here to stay with the protagonist.>#Ron
+have come here to stay with the protagonist.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -698,7 +698,7 @@ that it was a high-class succubus.
 It is rumored to have volunteered for remodeling itself,
 but the truth is not clear.
 Her quiet appearance and tone reassure the other party and
-let him be off guard.>#MTLed
+let him be off guard.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -711,7 +711,7 @@ Is it because she was remodeled
 When I extend my body to embrace the other person
 Emotions increase, and it changes to a slightly aroused,
 somewhat dignified tone.
-The range of the tentacle is about five meters.>#MTLed
+The range of the tentacle is about five meters.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -732,7 +732,7 @@ Just in the waist of the bustle style dress
 It's almost like putting your hand on the waist.
 The upper body can stretch up and down from the waist part
 Adjust yourself so that the other's head is received by the
-chest.>#MTLed
+chest.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -751,7 +751,7 @@ Those who are wrapped in her body are not alive and free.
 Her physical sense, not the original succubus
 The technique is sweet whispering, but love juice does it.
 It will be squeezed forever like a bowl that is licked in a
-huge mouth.>#MTLed
+huge mouth.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -770,7 +770,7 @@ When Iron Maiden catches prey from behind and caresses
 The tone and tone are slightly jerky.
 Some of the ones I wrote earlier will come from Aroused
 This time, something from her de S temperament is rather
-strong.>#MTLed
+strong.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -790,7 +790,7 @@ The penis is gently pinched from the left and right to the
 dress part of the lower body.
 Stimulate the vagina like stimulation by peeking up and
 down
-You can give it to the penis.>#MTLed
+You can give it to the penis.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -803,7 +803,7 @@ She was bored with her vain time.
 It is capricious to be caught by human beings, and it is
 also captivating to agree to remodeling.
 And it was also fancy to save the hero.
-But after coming to this room, she felt something changed.>#MTLed
+But after coming to this room, she felt something changed.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -835,7 +835,7 @@ A type of familiar that Hecate follows.
 Appears in the traveler's dreaming and sheds blood while
 showing nightmares and nasty dreams
 In the case of this shelter attack
-Modified to physical combat type.>#MTLed
+Modified to physical combat type.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -855,7 +855,7 @@ It is only reddish and soft fleshy wall only when it has a
 magical effect.
 This exquisite softness absorbs the shock of the prey's
 struggle
-The feeling also shakes the will of the prey's struggle.>#MTLed
+The feeling also shakes the will of the prey's struggle.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -876,7 +876,7 @@ concentrated.
 Usually, with the main tongue, while milking the opponent
 caught in the arm.
 I lick my opponent around me with my other tongue and I
-can't move.>#MTLed
+can't move.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -897,7 +897,7 @@ things
 It sucks in fluid and soul.
 If you look from the outside, just drink with a straw
 Is it like juice in a paper container?
-The protagonist, in a sense, was lucky.>#MTLed
+The protagonist, in a sense, was lucky.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -921,7 +921,7 @@ during battle.
 Still, I tried to bring the hero to this place
 Did you like the hero so much, or
 I thought that I thought that I could enjoy it without
-worrying about my surroundings.>#MTLed
+worrying about my surroundings.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -943,7 +943,7 @@ Charmed Because there is a magical power, one of the prey
 is
 It is not supposed to receive everything and in the head.
 Instead of being crazy, etc., my head is
-I am bombarded with a sensation of pleasure.>#MTLed
+I am bombarded with a sensation of pleasure.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -961,7 +961,7 @@ appearance now.
 Because there is a main character who will treat you
 without worrying about it
 She will be able to stay in that room without worrying
-about the dilemma.>#MTLed
+about the dilemma.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1001,7 +1001,7 @@ milk.
 The human who drank milk becomes a baby rabbit and has no
 life for three days.
 She loves her until she dies, searching for the next boy
-while crying.>#MTLed
+while crying.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1014,7 +1014,7 @@ Her voice makes the other party reassuring and offensive
 This has the same effect as the calm tone of Iron Maiden
 In the case of her, so that the other party does not run
 away with its own huge body
-There is a purpose to keep the opponent on the spot.>#MTLed
+There is a purpose to keep the opponent on the spot.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1034,7 +1034,7 @@ When wrapping the other party, it will cover so as not to
 be seen from the outside
 This is to protect your own 'boy' from outside enemies
 This is to prevent her from being aware of the enemy when
-she is hug someone.>#MTLed
+she is hug someone.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1052,7 +1052,7 @@ Make sure that the target receives the impact of a
 collision and blows it off
 At the same time as jumping, we have already begun to wrap
 in both hands.
-So much, her jumping speed is fast.>#MTLed
+So much, her jumping speed is fast.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1076,7 +1076,7 @@ On the contrary, it deprives you of the willingness and
 struggle to capture.
 Her hairdressing is done to the whole upper body
 It is said that the lower body is finally given up and
-sucked up.>#MTLed
+sucked up.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1095,7 +1095,7 @@ What is finally sad is the left herself.
 However, she who wants to come to my room and wants to be a
 hero is
 Certainly, it will be able to heal the hero's damaged heart
-Because it also becomes "salvation" of her own way.>#MTLed
+Because it also becomes "salvation" of her own way.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1122,7 +1122,7 @@ Appears in a place where people are not popular, such as
 the back of a convenience store
 In exchange for temptation of one's own body, I demand
 Pasiri.
-The approach is Haru and the instructions are Liz.>#MTLed
+The approach is Haru and the instructions are Liz.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1145,7 +1145,7 @@ It is only the human being who has a little feeling of
 "Furry".
 She seems to have the ability to distinguish such people
 It looks like a stray cat has a similar ability to screen
-Indulge Yourself humans.>#MTLed
+Indulge Yourself humans.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1166,7 +1166,7 @@ Her breasts are very attractive to her at the time she
 chooses
 If you have a chance, you will want to touch even a little.
 However, if they insist on their demands as their desires
-It will be painful.>#MTLed
+It will be painful.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1187,7 +1187,7 @@ Apply pressure to the prey and bound the entire body with
 exquisite tightening.
 Hoodie is part of Haru's Change
 Perhaps her hard-willed "I won't let go"
-It may not be the result that clearly appeared.>#MTLed
+It may not be the result that clearly appeared.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1206,7 +1206,7 @@ For Haru who likes whole body compression, this is also one
 of his favorite positions.
 Actually, the one with the other's face visible is the best
 The penis of the other party standing in front of you
-Treat like a partner like yourself>#MTLed
+Treat like a partner like yourself#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1228,7 +1228,7 @@ It doesn't matter if the opponent is Aroused, it's on the
 other's face
 Even if you hate hardships, the tail's fluffy attack
 Suck it in the crotch full of that smell
-It will be erected in a forced manner.>#MTLed
+It will be erected in a forced manner.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1250,7 +1250,7 @@ times as her clothes etc.
 There is also a reason that she likes this candy
 Recently, even to select people who are interested in their
 tongue use
-It seems to be useful.>#MTLed
+It seems to be useful.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1269,7 +1269,7 @@ She also shows extreme aversion to touching humans
 But for "what I want to see the other party's reaction", it
 is not that
 That she does a blowjob is a very well-loved proof.
-By nature, it will never be emitted from her mouth.>#MTLed
+By nature, it will never be emitted from her mouth.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1291,7 +1291,7 @@ bag.
 But at that time there was no dignity of As a human.
 If you're ready for pasili, they will just go back to their
 nostalgia
-It could be a real "money bag".>#MTLed
+It could be a real "money bag".#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1306,7 +1306,7 @@ Surely, Haru will be the same.
 Meet the protagonist, see the changing aspect of the
 partner
 Liz wants to forget the past and have fun now.
-Surely, Haru would be the same.>#MTLed
+Surely, Haru would be the same.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1338,7 +1338,7 @@ A pacifier has overtaken the milking doll invented by Yui.
 Of course, milking using demon's magic drive and technology
 Bound your opponent with endless hair and special
 abilities.
-Because it is a doll drive, walking itself is slow.>#MTLed
+Because it is a doll drive, walking itself is slow.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1361,7 +1361,7 @@ are also hidden cleanly
 It must have been a more lively skin color.
 But her skin is not
 It has the charm of never releasing something that has been
-touched once.>#MTLed
+touched once.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1381,7 +1381,7 @@ Stimulation is sent in the crotch while feeling her soft
 skin on the whole body.
 Hug function itself was originally given to the doll
 The player is locked automatically when the waist swing
-function is activated.>#MTLed
+function is activated.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1402,7 +1402,7 @@ Originally, long-term use is a crisis of life
 The Hug feature is also released in a fixed amount of time,
 and is now ready to go.
 But Mukuro fixed it with his own hair
-With your will, keep the waist swing forever.>#MTLed
+With your will, keep the waist swing forever.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1423,7 +1423,7 @@ It is fixed by this pose, and it only moves slightly
 according to the movement of the other party.
 Originally, users should be able to enjoy at their own pace
 In this position of Mukuro, it is the other party that the
-body is fixed.>#MTLed
+body is fixed.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1447,7 +1447,7 @@ tightness of the vagina and how to put weight.
 Mukuro himself understands the function of his body and
 always does the best milking.
 The problem is that she has complete control of her
-leadership.>#MTLed
+leadership.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1461,7 +1461,7 @@ We assume ourselves as "Mukuro" and try to live with the
 protagonist.
 Even though it is a relationship that you originally met
 for distorted reasons
-This is also a kind of kind, is it one of the gentle "raw"?>#MTLed
+This is also a kind of kind, is it one of the gentle "raw"?#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1488,7 +1488,7 @@ Realm TV.
 Fight against the backup dancers you summon in a dance
 match,
 We reverse rape as a highlight of the show with the people
-who lost.>#MTLed
+who lost.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1507,7 +1507,7 @@ The dance of Ebony is very slow and
 It is not difficult for her to follow her dance
 But most Fan Art humans are misled by her poses and sensual
 movements.
-I am invited to make a mistake in the dance.>#MTLed
+I am invited to make a mistake in the dance.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1526,7 +1526,7 @@ Lazy dance is very passionate and intense
 In order to follow normally, considerable physical ability
 is required.
 If she could show her a chance and get on her
-It will be violently committed according to the music Liz.>#MTLed
+It will be violently committed according to the music Liz.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1546,7 +1546,7 @@ humans
 I do a good dance that I can not think that it is the first
 time.
 I have to see a dance that brings out her pretty charm
-In the end you will endure yourself from her.>#MTLed
+In the end you will endure yourself from her.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1565,7 +1565,7 @@ Acts that do not follow her intention during the show
 You should refrain from taking action to ruin the show.
 She was originally a possessor of the Magus-class magic
 power
-Because it is not a demon that human beings are the enemy>#MTLed
+Because it is not a demon that human beings are the enemy#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1582,7 +1582,7 @@ M. O. W biological weapons E-002 "Marionette"
 this sentence
 ・ Meet her request as much as possible
 ・ Allowing her to 'dispose' an unwanted person comfortably
-・ Important, important our puppets ...>#MTLed
+・ Important, important our puppets ...#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1617,7 +1617,7 @@ When a human is near, it appears in front of the other in
 this form
 Make a harmless move and drag the other party into the
 water.
-He is not hostile or malicious.>#MTLed
+He is not hostile or malicious.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1645,7 +1645,7 @@ The innumerable small tentacles in the lower body are not
 only mucus
 A stream of powerful magic is constantly being conducted.
 The creature that touched this, as she thought
-"Thinking" is rewritten, and it becomes "baron">#MTLed
+"Thinking" is rewritten, and it becomes "baron"#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1664,7 +1664,7 @@ Echo gently accepts people who are approaching.
 Because she is purely in favor of the other
 At this point, there are not many people who don't
 struggle. .
-But that's what she thinks.>#MTLed
+But that's what she thinks.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1684,7 +1684,7 @@ form
 It is very dangerous because of the flow of powerful magic.
 I put this tongue in a kiss, but lastly, the other person
 is
-You will be forced to take energy.>#MTLed
+You will be forced to take energy.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1702,7 +1702,7 @@ You will be forced to take energy.>#MTLed
 She in slug form can travel on the ground
 It is not so fast compared to human speed.
 So I bundle the tentacles of my hair like a whip
-After making the other party fall, I slowly take it.>#MTLed
+After making the other party fall, I slowly take it.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1721,7 +1721,7 @@ Her lower body tentacles are just touching
 Can affect the other's thinking,
 If you cover your head directly in this form and do
 "brainwashing" at once
-Deeper, more fancy tribes are born in a short time>#MTLed
+Deeper, more fancy tribes are born in a short time#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1736,7 +1736,7 @@ without brainwashing"
 Find a way and feel happy.
 But do not be cautious
 For her, how to make your favorite person a barbarian
-Because it was "common sense" from ancient times.>#MTLed
+Because it was "common sense" from ancient times.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1765,7 +1765,7 @@ considerably
 Instead, it has the ability to steal away the other's
 knowledge
 As a magician, it should have a nonstandard magic power
-I am weak and I can not use it very much.>#MTLed
+I am weak and I can not use it very much.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1785,7 +1785,7 @@ Her riddle is something other than 'example guy'
 Only elementary school students can not answer.
 If you are offended by her appearance and show a chance
 It will fly and be bound.
-That is her aim.>#MTLed
+That is her aim.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1807,7 +1807,7 @@ In addition to that she is also strongly pulled between
 kisses
 Because I will push the full breasts without regret
 A normal human being who has Hug wrapped in her is
-You will be exhausted of all your spirit and knowledge.>#MTLed
+You will be exhausted of all your spirit and knowledge.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1829,7 +1829,7 @@ The method of mating and the way of milking are all about
 their own knowledge.
 She should have seen "Fella" too
 Maybe she's penis with 'ice' or something
-You may be thinking and serving.>#MTLed
+You may be thinking and serving.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1848,7 +1848,7 @@ Sphinx doesn't understand his chest and chest
 (I am not always conscious of it in the first place)
 However, because I know that the other party is interested
 part
-I know how to milking with a good breast.>#MTLed
+I know how to milking with a good breast.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1869,7 +1869,7 @@ more question it was ok
 I must have had much confidence in this position.
 Even so, I should have been to the hero for the first time
 This position is called "My Special Move"
-I feel a little bit overwhelmed.>#MTLed
+I feel a little bit overwhelmed.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1892,7 +1892,7 @@ In the first question, do you remember what she said?
 "It's not bad to be stupid"
 She simply wanted to love people, not reason or command
 Not a position to be killed and killed
-It would have been wanted to be "loved" existence.>#MTLed
+It would have been wanted to be "loved" existence.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1918,7 +1918,7 @@ underground.
 The character is cruel and I only think of people as food.
 Defeat your opponent with Afraid and scold it.
 My hobbies are to have a life expectancy or a beggar just
-before you ask.>#MTLed
+before you ask.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1938,7 +1938,7 @@ walking
 Use your foot and move quickly
 She walks up and down alternately like a human being,
 standing upright.
-You don't have to rush to chase your prey.>#MTLed
+You don't have to rush to chase your prey.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1957,7 +1957,7 @@ All parts like her human face are below.
 Her eyes are the red four parts of the head.
 The lower jaw has only a pseudo-mouth that speaks and gives
 a tongue
-All other organs are at other sites and do not exist there.>#MTLed
+All other organs are at other sites and do not exist there.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1979,7 +1979,7 @@ of the testis.
 In other words, it is a liquid that converts all the body's
 abilities into semen.
 This milking will continue until the cell activity is aged
-It is the hardest thing in her milking.>#MTLed
+It is the hardest thing in her milking.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -1993,7 +1993,7 @@ The best prey spice for her, 'Afraid'
 Does the hero always keep "Afraid" against himself?
 That is an important item for her.
 The hero for her is at any time
-It must be "the best food".>#MTLed
+It must be "the best food".#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2020,7 +2020,7 @@ tongue.
 The prey which has succumbed is put into the body from the
 abdomen
 You can liquefy your body as a preservation diet for
-Archeny.>#MTLed
+Archeny.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2042,7 +2042,7 @@ Although color and structure are almost the same as Empuse
 Because there is no milking tongue and there is no magic
 power of familiarity itself
 Although ordinary people can not stand it, it will not be
-as good as her.>#MTLed
+as good as her.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2071,7 +2071,7 @@ ability as a living thing.
 I take a gentle attitude towards prey that follows me in a
 manner that is bothersome.
 It is a merciless character to those who struggle to the
-end.>#MTLed
+end.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2091,7 +2091,7 @@ She has in her fangs a "neurotoxic" that makes her move.
 I used it for this game
 He had an antidote in advance as a measure.
 As a result, it hurts him even more
-It is ironic that it has become.>#MTLed
+It is ironic that it has become.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2107,7 +2107,7 @@ She enjoys simulated sex in milking for hours.
 Because it is done until the other party's spirit is
 exhausted
 The more prey you got, the more undamaged
-Her pleasure is growing.>#MTLed
+Her pleasure is growing.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2129,7 +2129,7 @@ It becomes a lubricant when passing through a snake body,
 and also becomes an Aroused agent.
 At this stage, there is no prey
 There is no choice but to leave herself to her who is the
-only one who cares.>#MTLed
+only one who cares.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2151,7 +2151,7 @@ As you can see from what you have done with Echo
 She does not use her partner's mucus at all.
 When bound to the protagonist, I left my hand and wound it
 around
-It may be a sign of great confidence.>#MTLed
+It may be a sign of great confidence.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2165,7 +2165,7 @@ She who kept herself by going crazy once
 In the protagonist beside me, I feel a moment of rest.
 However, the "imprinting" she did to keep herself
 It will never be the depth that the hero can heal
-She must be a monster and the hero must face each other.>#MTLed
+She must be a monster and the hero must face each other.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2197,7 +2197,7 @@ The language skills are low, but the intelligence is not
 low.
 Has a tail with a tentacle that erodes the other's nerve
 It has the ability to "parasitize" the other party using
-this.>#MTLed
+this.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2209,7 +2209,7 @@ this.>#MTLed
 Camazotz has separate wings on the head and waist
 Heli-like dexterous flight is possible.
 Besides, freely deform unused wings
-You can also attack external enemies like a knife.>#MTLed
+You can also attack external enemies like a knife.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2225,7 +2225,7 @@ You can also attack external enemies like a knife.>#MTLed
 When Camazotz seduces the other party, it performs
 parasitic milking
 I seek for a kiss for perseverance, and commit the other's
-mouth with a tongue.>#MTLed
+mouth with a tongue.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2236,7 +2236,7 @@ mouth with a tongue.>#MTLed
 At the time of parasitism, pleasures and feelings remain as
 they are
 For her, this pseudo mating itself is
-It is part of a fun 'play'.>#MTLed
+It is part of a fun 'play'.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2250,7 +2250,7 @@ It is part of a fun 'play'.>#MTLed
 一度挟まれると、普通の人間はふりほどくことができない
 > CONTEXT: Enemies/591/BookDescription/3
 Camazotz's leg power, classified as a sorrel, is incredible
-Once pinched, ordinary humans can not distract>#MTLed
+Once pinched, ordinary humans can not distract#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2258,7 +2258,7 @@ Once pinched, ordinary humans can not distract>#MTLed
 空中で獲物が弱るのを愉しそうに眺める。
 > CONTEXT: Enemies/591/BookDescription/5
 As it is, Camazotz rolls around the tail and climbs up.
-I enjoy watching the game weaken in the air.>#MTLed
+I enjoy watching the game weaken in the air.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2270,7 +2270,7 @@ I enjoy watching the game weaken in the air.>#MTLed
 > BEGIN STRING
 カマソッソの尻尾は、細かな触手やヒダで構成されており
 > CONTEXT: Enemies/592/BookDescription/3
-Camazotz's tail is made up of fine tentacles and folds>#MTLed
+Camazotz's tail is made up of fine tentacles and folds#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2280,7 +2280,7 @@ Camazotz's tail is made up of fine tentacles and folds>#MTLed
 > CONTEXT: Enemies/592/BookDescription/4
 It can also be used as a milking organ as it is.
 The pleasure that rubs and gives penis like a brush is
-Even if it is not parasitic, humans can not stand it.>#MTLed
+Even if it is not parasitic, humans can not stand it.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2292,13 +2292,13 @@ Even if it is not parasitic, humans can not stand it.>#MTLed
 The reason why Camazotz likes the protagonist is
 It must have been a simple motive like love at first sight.
 Because the hero accepted it and shared the spirit
-Her reassurance became established without parasitism.>#MTLed
+Her reassurance became established without parasitism.#MTLed
 > END STRING
 
 > BEGIN STRING
 彼女は、『伝える』のが少し下手なのだ。
 > CONTEXT: Enemies/593/BookDescription/7
-She is a little bad at "telling".>#MTLed
+She is a little bad at "telling".#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2314,7 +2314,7 @@ She is a little bad at "telling".>#MTLed
 A great monster of the wolf called "The Beautiful Woman of
 the Country (Insult)".
 The figure is imaginative and can be transformed into
-various forms.>#MTLed
+various forms.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2324,7 +2324,7 @@ various forms.>#MTLed
 In addition to his own powerful magic, he possesses many
 familiar
 I am looking forward to seeing the other party drowning
-myself.>#MTLed
+myself.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2333,19 +2333,19 @@ myself.>#MTLed
 > CONTEXT: Enemies/595/BookDescription/3
 Daccination is not only to be transformed, and to mislead
 humans
-He is good at reading the other's psychology and thoughts.>#MTLed
+He is good at reading the other's psychology and thoughts.#MTLed
 > END STRING
 
 > BEGIN STRING
 胸をはだけ、主人公を誘惑しようとしたのは
 > CONTEXT: Enemies/595/BookDescription/5
-I was only trying to seduce the hero>#MTLed
+I was only trying to seduce the hero#MTLed
 > END STRING
 
 > BEGIN STRING
 おそらく、主人公が胸ばかり見ていたからではないか
 > CONTEXT: Enemies/595/BookDescription/6
-Perhaps not because the hero was looking at the chest only>#MTLed
+Perhaps not because the hero was looking at the chest only#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2361,7 +2361,7 @@ Perhaps not because the hero was looking at the chest only>#MTLed
 > CONTEXT: Enemies/596/BookDescription/3
 The body of Dachki is slightly larger in size than humans.
 Each feminine part is then larger in size
-Is it a manifestation of her pride or just a preference>#MTLed
+Is it a manifestation of her pride or just a preference#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2369,7 +2369,7 @@ Is it a manifestation of her pride or just a preference>#MTLed
 抗いにくい身体といえる。
 > CONTEXT: Enemies/596/BookDescription/6
 Either way, physically or mentally for the other party
-It can be said that it is hard to resist.>#MTLed
+It can be said that it is hard to resist.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2382,13 +2382,13 @@ There is no human being able to get out of Dack's hug.
 Of course the feeling of pressure and pleasure transmitted
 from the skin and vagina
 She caress for the loser and gently caresses her.
-With the one eye that was swallowed and forged,>#MTLed
+With the one eye that was swallowed and forged,#MTLed
 > END STRING
 
 > BEGIN STRING
 快楽に負けた相手の心が折れてしまうのだ
 > CONTEXT: Enemies/597/BookDescription/7
-The mind of the other party who lost in pleasure breaks>#MTLed
+The mind of the other party who lost in pleasure breaks#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2408,7 +2408,7 @@ It is a special move of Dakchi who can play with the other
 party unable to move
 Wrapped in the body of a duck like a whole body weapon in
 sexual activity
-No one survived her fierce footsteps.>#MTLed
+No one survived her fierce footsteps.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2427,7 +2427,7 @@ Not only the dakki, but the tribe of sorceress
 Always cherish your own tail and ear coat.
 This is for the ancient sorcery to show off its ability
 It is said that it is a remnant that the coat and the
-number of tails were sit tass.>#MTLed
+number of tails were sit tass.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2445,7 +2445,7 @@ number of tails were sit tass.>#MTLed
 One of Dakchi's makeover forms.
 It is possible to generate pollen similar to Lampas.
 It is not homologous but secretes highly addictive honey.
-The lampas are modeled after the bound and shape of the ivy>#MTLed
+The lampas are modeled after the bound and shape of the ivy#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2460,7 +2460,7 @@ pulling
 Most probably, I'm conscious of Iron Maiden
 She is the main character and player
 By playing her who is trauma
-I'm inviting upset to that mind.>#MTLed
+I'm inviting upset to that mind.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2474,7 +2474,7 @@ I'm inviting upset to that mind.>#MTLed
 一度至近距離で拘束されると、脱出は不可能。
 > CONTEXT: Enemies/602/BookDescription/3
 This form is because the hair is composed of ivy
-Once bound at close range, escape is impossible.>#MTLed
+Once bound at close range, escape is impossible.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2484,7 +2484,7 @@ Once bound at close range, escape is impossible.>#MTLed
 During milking from a lily-like petal whose hands have
 changed
 A large amount of honey is poured in endlessly, and
-eventually it will be an abandoned man.>#MTLed
+eventually it will be an abandoned man.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2515,7 +2515,7 @@ It accurately embodies the characteristics of monsters, has
 agility and strength
 It is a form that is particularly enhanced.
 By the way, the intellect during transformation seems to be
-equal to barghest.>#MTLed
+equal to barghest.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2527,7 +2527,7 @@ equal to barghest.>#MTLed
 > BEGIN STRING
 このフォームのダッキの動きはやや単純で
 > CONTEXT: Enemies/604/BookDescription/3
-The movement of this form of duck is somewhat simple>#MTLed
+The movement of this form of duck is somewhat simple#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2537,7 +2537,7 @@ The movement of this form of duck is somewhat simple>#MTLed
 > CONTEXT: Enemies/604/BookDescription/4
 As with the barghest, they are jumping for copulation.
 But its physique is not comparable to barghest
-Once assembled, the escape will be difficult.>#MTLed
+Once assembled, the escape will be difficult.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2558,14 +2558,14 @@ Strong in physics, weak in lightning#MTLed
 > CONTEXT: Enemies/605/BookDescription/5
 She wears slime gel like a dress on her whole body
 It has the property of almost making prevention of physics
-attack.>#MTLed
+attack.#MTLed
 > END STRING
 
 > BEGIN STRING
 戦い方が特殊で、ダンスやキスで誘惑しながら攻撃してくる。
 > CONTEXT: Enemies/605/BookDescription/7
 The way of fighting is special, and it attacks while
-tempting with dance and kiss.>#MTLed
+tempting with dance and kiss.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2577,7 +2577,7 @@ tempting with dance and kiss.>#MTLed
 > BEGIN STRING
 このフォームのダッキは、筋力はそこまでないため
 > CONTEXT: Enemies/606/BookDescription/3
-Because this form of ducchi has no strength>#MTLed
+Because this form of ducchi has no strength#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2589,7 +2589,7 @@ Dare, I will not put force on Hug.
 This is the opposite, when a person gently and slowly
 approaches the lips
 Dach uses the characteristic of tending to forgive the
-mind.>#MTLed
+mind.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2601,7 +2601,7 @@ mind.>#MTLed
 > BEGIN STRING
 ダッキの知識吸いは、スフィンクスのように
 > CONTEXT: Enemies/607/BookDescription/3
-Duck's sucking on knowledge, like Sphinx>#MTLed
+Duck's sucking on knowledge, like Sphinx#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2611,13 +2611,13 @@ Duck's sucking on knowledge, like Sphinx>#MTLed
 > CONTEXT: Enemies/607/BookDescription/4
 There is no tendency to forget deeply to pinpoint.
 This is probably the purpose of sucking Duck's knowledge
-There is no matter that I do not let you answer the mystery>#MTLed
+There is no matter that I do not let you answer the mystery#MTLed
 > END STRING
 
 > BEGIN STRING
 快楽に堕とすことに傾倒しているからだろう。
 > CONTEXT: Enemies/607/BookDescription/7
-It is probably because he is obsessed with pleasure.>#MTLed
+It is probably because he is obsessed with pleasure.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2629,7 +2629,7 @@ It is probably because he is obsessed with pleasure.>#MTLed
 > BEGIN STRING
 このフォームの下半身は、ジェルを纏っているように見えるが
 > CONTEXT: Enemies/608/BookDescription/3
-The lower body of this form appears to crawl on the gel>#MTLed
+The lower body of this form appears to crawl on the gel#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2651,7 +2651,7 @@ Once imported, it will never be alive again>.#MTLed
 Kizuna asking for Dacchi as a protagonist is
 It is neither a straight love, nor a sinful sincerity.
 I duly crave the body of Dacchi who crashed into Dacchi
-It is a figure that is an "obedient" human being.>#MTLed
+It is a figure that is an "obedient" human being.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2663,7 +2663,7 @@ It is a figure that is an "obedient" human being.>#MTLed
 > BEGIN STRING
 天使の魔力が暴走した『神の悪意』。
 > CONTEXT: Enemies/610/BookDescription/4
-The angel's magic ran away and "God's malice".>#MTLed
+The angel's magic ran away and "God's malice".#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2673,14 +2673,14 @@ The angel's magic ran away and "God's malice".>#MTLed
 A charity-filled pure angel's magic is reversed with evil
 evil spirits
 It has been transformed into an insatiable desire to
-destroy "Hakoba".>#MTLed
+destroy "Hakoba".#MTLed
 > END STRING
 
 > BEGIN STRING
 完全体となれば、一瞬で世界が滅亡してしまう力を持つ。
 > CONTEXT: Enemies/610/BookDescription/7
 If it becomes perfect, it has the power to destroy the
-world in an instant.>#MTLed
+world in an instant.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2698,13 +2698,13 @@ world in an instant.>#MTLed
 Lost Reina needed to fully materialize
 A figure of Samael who lost his ego.
 No longer has the power to destroy the world
-Try to destroy the surroundings until it disappears>#MTLed
+Try to destroy the surroundings until it disappears#MTLed
 > END STRING
 
 > BEGIN STRING
 はた迷惑な悪魔と成り果てている。
 > CONTEXT: Enemies/611/BookDescription/8
-It is a dead demon.>#MTLed
+It is a dead demon.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2723,27 +2723,27 @@ There are many mystery#MTLed
 魔界と人間界を介して、様々な世界を渡り歩く行商人。
 > CONTEXT: Enemies/612/BookDescription/4
 Peddler walking across the various worlds through Demon
-Realm and the human realm.>#MTLed
+Realm and the human realm.#MTLed
 > END STRING
 
 > BEGIN STRING
 鬼にしては珍しく、戦いを好まず、商売上中立を保つ
 > CONTEXT: Enemies/612/BookDescription/5
 Uncommon for demons, do not like battles, keep business
-neutral>#MTLed
+neutral#MTLed
 > END STRING
 
 > BEGIN STRING
 だが実際のところは、並々ならぬ実力を持っており。
 > CONTEXT: Enemies/612/BookDescription/6
-But in fact, they have extraordinary abilities.>#MTLed
+But in fact, they have extraordinary abilities.#MTLed
 > END STRING
 
 > BEGIN STRING
 彼女が『悪魔』の枠に入るのかすら疑問だ。
 > CONTEXT: Enemies/612/BookDescription/7
 It is doubtful that she will fall within the frame of
-demon.>#MTLed
+demon.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2758,19 +2758,19 @@ demon.>#MTLed
 > CONTEXT: Enemies/613/BookDescription/3
 She is wearing more exposed clothes than necessary
 Other than "the goods", it is because it is ready to pay
-the price.>#MTLed
+the price.#MTLed
 > END STRING
 
 > BEGIN STRING
 事実、彼女は性技のテクニックにも淫魔並に精通しており
 > CONTEXT: Enemies/613/BookDescription/5
-In fact, she is as addicted to sex techniques as she is>#MTLed
+In fact, she is as addicted to sex techniques as she is#MTLed
 > END STRING
 
 > BEGIN STRING
 パイズリは、彼女のもっとも得意とする体位だ。
 > CONTEXT: Enemies/613/BookDescription/6
-tit-fuck is her best position.>#MTLed
+tit-fuck is her best position.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2782,7 +2782,7 @@ tit-fuck is her best position.>#MTLed
 > BEGIN STRING
 百鬼は、鬼としては筋肉量は少ない
 > CONTEXT: Enemies/614/BookDescription/3
-Hyakki has less muscle mass as a demon>#MTLed
+Hyakki has less muscle mass as a demon#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2791,13 +2791,13 @@ Hyakki has less muscle mass as a demon>#MTLed
 > CONTEXT: Enemies/614/BookDescription/4
 But when she gets caught, she is tightened enough to
 struggle
-Her "forced to try milking as you wish">#MTLed
+Her "forced to try milking as you wish"#MTLed
 > END STRING
 
 > BEGIN STRING
 さすが鬼の種族といったところだろう。
 > CONTEXT: Enemies/614/BookDescription/6
-It is probably a place like the demon race.>#MTLed
+It is probably a place like the demon race.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2867,7 +2867,7 @@ ancient disaster.
 Because they have appeared in the same manner as the
 women's stories and the past
 It is speculated that it has the ability to transcend
-space-time.>#MTLed
+space-time.#MTLed
 > END STRING
 
 > BEGIN STRING
@@ -2889,7 +2889,7 @@ scolds blood and flesh.
 On the contrary, the energetic person like a hero does not
 attack.
 While Harpy carries his soul to the underworld, Modoki
-brings it to hell.>#MTLed
+brings it to hell.#MTLed
 > END STRING
 
 > BEGIN STRING

--- a/Patch/Gaijinizer/Eval/Gaijinizer.rb
+++ b/Patch/Gaijinizer/Eval/Gaijinizer.rb
@@ -187,7 +187,7 @@ def self.update_note(note, index_array, to_hash, var, regex = @note_regex)
 			if a[-2] == "BookAttribute"
 			  tled_text = "#{@book_attribute_start}#{tled_text}>"
 			else#if a[-1] == "BookDescription"
-			  tled_text = "#{@book_description_start}#{tled_text.gsub(/\n/, ">\r\n#{@book_description_start}")}"
+			  tled_text = "#{@book_description_start}#{tled_text.gsub(/\n/, ">\r\n#{@book_description_start}")}>"
 			end
 		  end
 		  note[raw_data[i][1][0]..(raw_data[i][1][1] - 1)] = tled_text if tled_text #mutating


### PR DESCRIPTION
With Anego's help, we identified that the patcher wasn't handling BookAttribute lines correctly, not closing the tags. Now that we have fixed this, we can remove the workaround.