### PR TITLE
Fix for ending crashes

### DIFF
--- a/Gaijinizer patch/Map208.txt
+++ b/Gaijinizer patch/Map208.txt
@@ -412,5 +412,5 @@ DEVIL'S OFFICE#MTLed
 > BEGIN STRING
 "【＃５　孤独な戦い】"
 > CONTEXT: Map208/events/8/pages/0/276/InlineScript/2:1
-"[#5 A War, Alone]"#Ron
+"[＃5 A War, Alone]"#Ron
 > END STRING

--- a/Gaijinizer patch/Map211.txt
+++ b/Gaijinizer patch/Map211.txt
@@ -142,5 +142,5 @@ I won't hesitate anymore!!#Ron
 > BEGIN STRING
 "【＃６　獣になった猟師】"
 > CONTEXT: Map211/events/2/pages/0/217/InlineScript/2:1
-"[#6 He Who Fights Monsters]"#Ron
+"[＃6 He Who Fights Monsters]"#Ron
 > END STRING

--- a/Gaijinizer patch/Map214.txt
+++ b/Gaijinizer patch/Map214.txt
@@ -399,5 +399,5 @@ DEVIL'S OFFICE#MTLed
 > BEGIN STRING
 "【＃４　あえて賢者達の駒として】"
 > CONTEXT: Map214/events/1/pages/0/221/InlineScript/2:1
-"[#4 The Wise Men's Pawn]"#Ron
+"[＃4 The Wise Men's Pawn]"#Ron
 > END STRING


### PR DESCRIPTION
Using the English hash instead of the Japanese hash is causing the crashes. Have tested to confirm the cause of the crash, and tested to confirm the fix works.