### PR TITLE
EX4-14

### DIFF
--- a/Gaijinizer patch/CommonEvents_730.txt
+++ b/Gaijinizer patch/CommonEvents_730.txt
@@ -1,22 +1,25 @@
 ﻿> GAIJINIZER PATCH FILE
 > BEGIN STRING
 \\{\\{\\N[1]くん！！！
-> CONTEXT: CommonEvents_730/75/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: CommonEvents_730/75/Dialogue/enemy29
+\\{\\{\\N[1]-kun!!!#Ron
 > END STRING
 
 > BEGIN STRING
 …………………普通の……なら、………かもしれませんが
 
 あいにく、私たちは彼の…………ですから………
-> CONTEXT: CommonEvents_730/82/Dialogue/enemy40 < UNTRANSLATED
+> CONTEXT: CommonEvents_730/82/Dialogue/enemy40
+......... under normal conditions...... could...
 
+Unfortunately, because...... we...... his.....#Ron
 > END STRING
 
 > BEGIN STRING
 \\C[10]彼が、私たちに示してくれたこと……
 
 私たちは、彼から何を学びましたか……？
-> CONTEXT: CommonEvents_730/87/Dialogue/enemy40 < UNTRANSLATED
-
+> CONTEXT: CommonEvents_730/87/Dialogue/enemy40
+\\C[10]And we've learned a thing or two from all the
+things he's shown us.#RonLocalization
 > END STRING

--- a/Gaijinizer patch/CommonEvents_737.txt
+++ b/Gaijinizer patch/CommonEvents_737.txt
@@ -3,22 +3,28 @@
 うそでしょ……！？\\|
 
 \\C[2]サマエルの力を自分で制御してる…！！？
-> CONTEXT: CommonEvents_737/22/Dialogue/enemy29 < UNTRANSLATED
+> CONTEXT: CommonEvents_737/22/Dialogue/enemy29
+There's no way!!\\|
 
+\\C[2]He's actually controlling Samael's power himself!#Ron
 > END STRING
 
 > BEGIN STRING
 これが\\C[10]特異点……
 
 『運命を変える力』……！？
-> CONTEXT: CommonEvents_737/26/Dialogue/enemy29 < UNTRANSLATED
+> CONTEXT: CommonEvents_737/26/Dialogue/enemy29
+This is the \\C[10]Singularity...
 
+The power to change fate!!#Ron
 > END STRING
 
 > BEGIN STRING
 ああああああああああああああああああああああ！！！！
 
 あああああああああ！！！！！！！！！！
-> CONTEXT: CommonEvents_737/82/Dialogue/enemy40 < UNTRANSLATED
+> CONTEXT: CommonEvents_737/82/Dialogue/enemy40
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAH!!!
 
+AAAAAAAAAAAAAAAAH!!!!!!!!!!#Ron
 > END STRING

--- a/Gaijinizer patch/Enemies.txt
+++ b/Gaijinizer patch/Enemies.txt
@@ -493,7 +493,7 @@ Chimera Beast#Ron
 > CONTEXT: Enemies/361/name
 > CONTEXT: Enemies/362/name
 > CONTEXT: Enemies/363/name
-Abyss Abaddon#Ron
+Abyssal Abaddon#Ron
 > END STRING
 
 > BEGIN STRING

--- a/Gaijinizer patch/Map453.txt
+++ b/Gaijinizer patch/Map453.txt
@@ -42,32 +42,40 @@
 
 > BEGIN STRING
 ぐううっ……！！
-> CONTEXT: Map453/events/2/pages/0/25/Dialogue/kazuya < UNTRANSLATED
-> CONTEXT: Map530/events/7/pages/0/571/Dialogue/kazuya < UNTRANSLATED
-
+> CONTEXT: Map453/events/2/pages/0/25/Dialogue/kazuya
+> CONTEXT: Map530/events/7/pages/0/571/Dialogue/kazuya
+Guuugh!!#Ron
 > END STRING
 
 > BEGIN STRING
 さぁ……\\|
 
 ゆっくりと意識を集中させて、\\|\\N[1]\\|\\|\\^
-> CONTEXT: Map453/events/2/pages/0/40/Dialogue/other8 < UNTRANSLATED
+> CONTEXT: Map453/events/2/pages/0/40/Dialogue/other8
+Now...\\|
 
+Slowly focus your mind, \\|\\N[1]\\|\\|\\^#Ron
 > END STRING
 
 > BEGIN STRING
 今のキミなら、その力を制御できるはず\\|
 
 その強い意志で、君の願いを叶えるんだ。\\|\\|\\|\\^
-> CONTEXT: Map453/events/2/pages/0/44/Dialogue/other8 < UNTRANSLATED
-> CONTEXT: Map530/events/7/pages/0/594/Dialogue/enemy29 < UNTRANSLATED
+> CONTEXT: Map453/events/2/pages/0/44/Dialogue/other8
+> CONTEXT: Map530/events/7/pages/0/594/Dialogue/enemy29
+You should be able to control that power.\\|
 
+You can use that strong will of yours to make
+your wishes come true.\\|\\|\\|\\^#Ron
 > END STRING
 
 > BEGIN STRING
 \\C[10]世界を救うために、世界を壊す……\\|\\|
 
 今こそキミ自身が『世界の破壊者』になる時だ…！！！\\|\\|\\|\\|\\^
-> CONTEXT: Map453/events/2/pages/0/55/Dialogue/other8 < UNTRANSLATED
+> CONTEXT: Map453/events/2/pages/0/55/Dialogue/other8
+\\C[10]Destroy the world to save your own...\\|\\|
 
+Now is the time for you to become the "Destroyer
+of Worlds"!!!\\|\\|\\|\\|\\^#Ron
 > END STRING

--- a/Gaijinizer patch/Map467.txt
+++ b/Gaijinizer patch/Map467.txt
@@ -46,7 +46,7 @@ after all. ♡♡♡#Ron
 このショタコンヘビめ！！
 > CONTEXT: Map467/events/21/pages/0/24/Dialogue/alice_fc6
 Cut the crap!! Like anyone would take you up on
-that, you stupid pedo snake!!#RonLocalisation
+that, you stupid pedo snake!!#RonLocalization
 > END STRING
 
 > BEGIN STRING

--- a/Gaijinizer patch/Map530.txt
+++ b/Gaijinizer patch/Map530.txt
@@ -42,8 +42,7 @@ having to use my braids to move. ♪#Ron
 > CONTEXT: Map530/events/7/pages/0/25/Dialogue/enemy2
 Haah... So you ended up bringing me with you...
 
-I'm going home now that I've lost all my
-motivation.#Ron
+I'm bored now, I'm going home.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -74,8 +73,9 @@ trying to get your revenge on me?#Ron
 僕を始末することぐらい、簡単だったはずじゃ……
 > CONTEXT: Map530/events/7/pages/0/49/Dialogue/kazuya
 \\C[2]You wouldn't have had to turn to the Old One for
-help if you'd used it, and dealing with me
-would've been a cinch.#Ron
+help if you'd used it. 
+
+It would have been easy to deal with me.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -131,8 +131,8 @@ human.#Ron
 > CONTEXT: Map530/events/7/pages/0/72/Dialogue/enemy2
 Though in hindsight, this was showing off in its
 own way as well. Thinking about it now, maybe
-you should have used your full power to destroy
-it.#CheckLater
+I should have used my full power from the start
+to destroy *you*.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -401,10 +401,11 @@ risk their very existences by fighting him.#Ron
 アバドーンの身体をかき乱して、僕たちにチャンスを作ってる
 > CONTEXT: Map530/events/7/pages/0/326/Dialogue/enemy29
 Though they themselves weren't to blame, \\C[10]with
-tears in their eyes they took the sins of the
-Interveners who had decided their path, and used
-them to throw Abaddon's body into disarray.
-They bought us a chance.#RonIffyWording
+tears in their eyes they bore the sins of the
+Interveners, and used that burden to throw
+Abaddon's body into disarray.
+\\C[10]In other words, they sacrificed themselves to
+buy us a chance.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -694,10 +695,10 @@ this everything we've got!#Ron
 
 ならばそれに応え、我も悔いを残さず、全力で臨むだけだ。
 > CONTEXT: Map530/events/7/pages/0/472/Dialogue/enemy35
-Marion's also made up his mind so he wouldn't
-listen to me even if I tried to oppose the idea.
-In which case I'll respond to that by giving this
-everything I've got with no regrets.#Ron
+Marion's also made up his mind. He wouldn't
+listen to me even if I disagreed...
+In that case, I'll listen to him by giving this
+everything I've got, with no regrets.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -801,7 +802,7 @@ angelic magic going berserk?#Ron
 Let's see... \\C[10]not for very long\\C[0].
 But don't worry, compared to the incomplete Samael
 you saw last time, \\C[2]this one's firepower will be
-only a completely different level\\C[0].#Ron
+on a completely different level\\C[0].#Ron
 > END STRING
 
 > BEGIN STRING

--- a/Gaijinizer patch/Map530.txt
+++ b/Gaijinizer patch/Map530.txt
@@ -8,16 +8,18 @@
 
 > BEGIN STRING
 か、帰ってこれ…た…？
-> CONTEXT: Map530/events/7/pages/0/10/Dialogue/ruka_fc1 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/10/Dialogue/ruka_fc1
+A-Are we... back?#Ron
 > END STRING
 
 > BEGIN STRING
 一応、アバドーンの外には出たって感じかな……
 
 まだ多元宇宙の空間だけど……
-> CONTEXT: Map530/events/7/pages/0/12/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/12/Dialogue/enemy29
+It feels like we're out of Abaddon now at the
+very least. We're still in the multiverse space,
+though.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -25,8 +27,11 @@
 
 やっぱり五体満足って快適だわー
 三つ編みで動くのはもうコリゴリだよ。
-> CONTEXT: Map530/events/7/pages/0/16/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/16/Dialogue/enemy29
+Aah, but still, I haven't felt this refreshed
+in a long time. It really does feel great to be
+in peak physical form. I was getting sick of
+having to use my braids to move. ♪#Ron
 > END STRING
 
 > BEGIN STRING
@@ -34,16 +39,21 @@
 結局、一緒に連れてこられちゃったわね……
 
 萎えちゃったから帰るわ
-> CONTEXT: Map530/events/7/pages/0/25/Dialogue/enemy2 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/25/Dialogue/enemy2
+Haah... So you ended up bringing me with you...
 
+I'm going home now that I've lost all my
+motivation.#Ron
 > END STRING
 
 > BEGIN STRING
 アバドーンをぶっ潰すの、後はあんたらに任せるわよ。
 
 今度はしくじらないようにね。
-> CONTEXT: Map530/events/7/pages/0/30/Dialogue/enemy2 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/30/Dialogue/enemy2
+I'll leave the Abaddon beat-down to you guys.
 
+Try not to mess up this time.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -51,32 +61,42 @@
 
 キミは……僕に復讐をするときに
 なぜ\\C[24]あの力\\C[0]で僕を襲わなかったんだ？
-> CONTEXT: Map530/events/7/pages/0/44/Dialogue/kazuya < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/44/Dialogue/kazuya
+Can I ask you something before you go?
 
+Why didn't you use \\C[24]that power \\C[0]when you were
+trying to get your revenge on me?#Ron
 > END STRING
 
 > BEGIN STRING
 \\C[2]あんな力があるなら、わざわざオールドワンに加担せずとも
 
 僕を始末することぐらい、簡単だったはずじゃ……
-> CONTEXT: Map530/events/7/pages/0/49/Dialogue/kazuya < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/49/Dialogue/kazuya
+\\C[2]You wouldn't have had to turn to the Old One for
+help if you'd used it, and dealing with me
+would've been a cinch.#Ron
 > END STRING
 
 > BEGIN STRING
 はぁ……それ説明しなきゃダメ？
 
 まぁいいわ、ついでだから教えてあげる。
-> CONTEXT: Map530/events/7/pages/0/54/Dialogue/enemy2 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/54/Dialogue/enemy2
+Haah... Do I really have to explain myself?
 
+Well whatever, I might as well while I'm here.#Ron
 > END STRING
 
 > BEGIN STRING
 あの姿は、\\C[2]以前の私の姿なの。
 
 魔界の情勢や抗争に関わってた、権力を誇示してた頃の姿。
-> CONTEXT: Map530/events/7/pages/0/58/Dialogue/enemy2 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/58/Dialogue/enemy2
+What you saw back there was my \\C[2]previous form.
 
+It's the one I took to flaunt my power during
+times of strife and discord in the Demon Realm.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -84,8 +104,11 @@
 一つ戦争が勃発すれば、領地の一部も荒れ果てる。
 
 私は、そういうのに嫌気がさしたのよ。
-> CONTEXT: Map530/events/7/pages/0/62/Dialogue/enemy2 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/62/Dialogue/enemy2
+I was sick of parts of my territory being
+devastated because of wars breaking out over the
+death of a subordinates trying to show off their
+power to one another.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -93,8 +116,11 @@
 
 \\C[2]私にとって\\C[24]あの姿\\C[2]は二度と戻りたくない姿だった。
 人間への復讐で使うなんてもってのほかよ。
-> CONTEXT: Map530/events/7/pages/0/67/Dialogue/enemy2 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/67/Dialogue/enemy2
+That's why I put everything I had into \\C[24]that form\\C[0].
+\\C[2]I never wanted to change back into it that ever again.
+It'd be absurd to use it just to get revenge on a
+human.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -102,8 +128,11 @@
 
 今思えば、
 アンタは最初から全力で消すべきだったのかもしれないわ。
-> CONTEXT: Map530/events/7/pages/0/72/Dialogue/enemy2 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/72/Dialogue/enemy2
+Though in hindsight, this was showing off in its
+own way as well. Thinking about it now, maybe
+you should have used your full power to destroy
+it.#CheckLater
 > END STRING
 
 > BEGIN STRING
@@ -111,24 +140,31 @@
 可愛くないでしょ、あんなの。
 
 気に入ってんのよね、この姿。
-> CONTEXT: Map530/events/7/pages/0/80/Dialogue/enemy2 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/80/Dialogue/enemy2
+Besides, that form isn't nearly as cute.
 
+I like this one much more.#Ron
 > END STRING
 
 > BEGIN STRING
 人間を相手にするなら、この姿で十分……
 
 ガキだから甘い顔するヤツも大勢居るしね…♡
-> CONTEXT: Map530/events/7/pages/0/85/Dialogue/enemy2 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/85/Dialogue/enemy2
+It's also much better when I'm spending time with
+humans. There are lots of guys out there who
+can't help but fawn over me because I look like a
+little brat. ♡#Ron
 > END STRING
 
 > BEGIN STRING
 あ？なにジロジロ見てんのよ、クソネコ。
 
 何か文句でもあるわけ？
-> CONTEXT: Map530/events/7/pages/0/95/Dialogue/enemy2 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/95/Dialogue/enemy2
+Huh? What're you staring at, you shitty cat?
 
+You got something to say to me?#Ron
 > END STRING
 
 > BEGIN STRING
@@ -136,8 +172,10 @@
 
 \\C[2]ヘカーテはどうやって\\N[1]くんの場所を
 特定したんだろうなーって。
-> CONTEXT: Map530/events/7/pages/0/99/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/99/Dialogue/enemy29
+Well, it's just a question since you saved me
+and all. \\C[2]How did you manage to pinpoint
+\\N[1]-kun's location?#Ron
 > END STRING
 
 > BEGIN STRING
@@ -145,30 +183,37 @@
 
 \\N[1]くんの場所が分かれば、
 必然的に分かる、っていうのは理解できるんだけど……
-> CONTEXT: Map530/events/7/pages/0/104/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/104/Dialogue/enemy29
+I know that Luka-kun and Marion-kun are connected
+to me by that mark, so they knew where
+\\N[1]-kun was the moment I did...#Ron
 > END STRING
 
 > BEGIN STRING
 …………ははーん？
 
 そういうことか……♡
-> CONTEXT: Map530/events/7/pages/0/111/Dialogue/enemy29 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/111/Dialogue/enemy29
+Ooooh...
 
+That's how you knew... ♡#Ron
 > END STRING
 
 > BEGIN STRING
 \\C[2]『マイルームで表されるものが全てじゃない』\\C[0]……
 
 その執拗な執念を考えると、納得だね……♪
-> CONTEXT: Map530/events/7/pages/0/115/Dialogue/enemy29 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/115/Dialogue/enemy29
+\\C[2]Not everyone in My Room is shown as such\\C[0]...
 
+It makes sense when you consider how obsessed
+with him you've been... ♪#Ron
 > END STRING
 
 > BEGIN STRING
 ああ、なるほど……
-> CONTEXT: Map530/events/7/pages/0/119/Dialogue/ruka_fc1 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/119/Dialogue/ruka_fc1
+Ah, I see...#Ron
 > END STRING
 
 > BEGIN STRING
@@ -176,8 +221,10 @@
 
 知らないわよ！コイツの居場所が分かった理由なんて！！
 なんとなく見つけただけよ！！
-> CONTEXT: Map530/events/7/pages/0/126/Dialogue/enemy3 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/126/Dialogue/enemy3
+Hah?! What kind of stupid conclusions are you
+jumping to?! I have no idea why I knew where he
+was!! I just somehow managed to find him!!#Ron
 > END STRING
 
 > BEGIN STRING
@@ -185,8 +232,11 @@
 
 なんなら今度会ったら消し炭にしてやるんだから！
 二度と私の前に現れるんじゃないわよ！！
-> CONTEXT: Map530/events/7/pages/0/131/Dialogue/enemy3 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/131/Dialogue/enemy3
+Me and this guy aren't like that!!
 
+I'll burn you to a crisp the next time I see you!
+Don't ever show your face in front of me again!!#Ron
 > END STRING
 
 > BEGIN STRING
@@ -194,16 +244,21 @@
 わかってるよ……ヘカーテ……
 
 助けてくれてありがとう……
-> CONTEXT: Map530/events/7/pages/0/137/Dialogue/kazuya < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/137/Dialogue/kazuya
+R-Right...
 
+Got it, Hecate...
+Thanks for saving me...#Ron
 > END STRING
 
 > BEGIN STRING
 ぜんっぜん分かってない！！
 
 アンタ、また私のこと見くびってるんじゃないでしょうね！
-> CONTEXT: Map530/events/7/pages/0/143/Dialogue/enemy3 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/143/Dialogue/enemy3
+You don't get it at all!!
 
+You're making fun of me again!!#Ron
 > END STRING
 
 > BEGIN STRING
@@ -211,28 +266,33 @@
 
 帰る！！！
 二度とツラ見せるんじゃないわよ！！！
-> CONTEXT: Map530/events/7/pages/0/147/Dialogue/enemy3 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/147/Dialogue/enemy3
+Aaah, I'm so mad right now!!!
 
+I'm going home!!!
+You'd better hope we don't meet again!!!#RonLocalization
 > END STRING
 
 > BEGIN STRING
 ………素直になれないって、大変だね。
-> CONTEXT: Map530/events/7/pages/0/182/Dialogue/ruka_fc1 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/182/Dialogue/ruka_fc1
+The ones who can't be honest are such a handful.#Ron
 > END STRING
 
 > BEGIN STRING
 \\N[1]くん！！
-> CONTEXT: Map530/events/7/pages/0/256/Dialogue/enemy30 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/256/Dialogue/enemy30
+\\N[1]-kun!!#Ron
 > END STRING
 
 > BEGIN STRING
 みんな！
 
 無事だったんだね！
-> CONTEXT: Map530/events/7/pages/0/261/Dialogue/ruka_fc1 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/261/Dialogue/ruka_fc1
+You guys!
 
+Are you alright?!#Ron
 > END STRING
 
 > BEGIN STRING
@@ -240,8 +300,11 @@
 
 戦闘中、いきなりお前たちの姿が消えてしまうわ
 いきなり目の前のアバドーンは暴れ出すわで、大変だったぞ！
-> CONTEXT: Map530/events/7/pages/0/266/Dialogue/alice_fc5 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/266/Dialogue/alice_fc5
+That's what we should be asking, you idiot!!
+You guys suddenly disappeared in the middle of
+the battle, and then Abaddon started going nuts!
+It was crazy!#Ron
 > END STRING
 
 > BEGIN STRING
@@ -249,54 +312,65 @@
 もしかしたら……と思ってしまっていたが……
 
 ３人とも無事で何よりだ……
-> CONTEXT: Map530/events/7/pages/0/271/Dialogue/enemy35 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/271/Dialogue/enemy35
+We thought the worst might have happened when
+Abaddon's World Fusion power strengthened all at
+once. I'm glad the three of you are unhurt.#Ron
 > END STRING
 
 > BEGIN STRING
 サッキノ　魔王　カオ真っ赤
 
 油断シテ　パンツ　マルミエ
-> CONTEXT: Map530/events/7/pages/0/276/Dialogue/enemy37 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/276/Dialogue/enemy37
+THAT DEMON KING'S FACE BRIGHT RED...
 
+SHE GOT CARELESS, SAW HER PANTIES...#Ron
 > END STRING
 
 > BEGIN STRING
 ………オルトロス
-> CONTEXT: Map530/events/7/pages/0/280/Dialogue/enemy37 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/280/Dialogue/enemy37
+Orthrus...#Ron
 > END STRING
 
 > BEGIN STRING
 ｸﾞﾙﾙ……
 
 シャベリタイ……
-> CONTEXT: Map530/events/7/pages/0/282/Dialogue/enemy37 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/282/Dialogue/enemy37
+Grrr...
 
+WANTED TO TALK...#Ron
 > END STRING
 
 > BEGIN STRING
 ……それで？
 
 アバドーンは、どうなったの？
-> CONTEXT: Map530/events/7/pages/0/286/Dialogue/enemy38 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/286/Dialogue/enemy38
+So what happened with Abaddon?#Ron
 > END STRING
 
 > BEGIN STRING
 ああ………あぁぁぁぁ………
 
 ふぅぇ………しジュ………
-> CONTEXT: Map530/events/7/pages/0/307/Dialogue/enemy40 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/307/Dialogue/enemy40
+AAAH... AAaaaaah...
 
+Fuuugh... Jeegh...#Ron
 > END STRING
 
 > BEGIN STRING
 な、なんだあの姿は……
 
 もはや原形を留めておらんではないか……！
-> CONTEXT: Map530/events/7/pages/0/311/Dialogue/alice_fc5 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/311/Dialogue/alice_fc5
+W-What's that?!
 
+Has he lost the ability to maintain his base
+form?!#Ron
 > END STRING
 
 > BEGIN STRING
@@ -304,8 +378,9 @@
 アバドーンの魔力そのものが、かなり乱れている……
 
 いったい、ヤツの身になにが…！？
-> CONTEXT: Map530/events/7/pages/0/315/Dialogue/enemy35 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/315/Dialogue/enemy35
+It's not just his form... his magic itself is
+also running wild. What on earth happened to him?#Ron
 > END STRING
 
 > BEGIN STRING
@@ -313,8 +388,10 @@
 自分の存在を賭して……
 
 \\C[10]彼らの介入者の過ちをも背負って……
-> CONTEXT: Map530/events/7/pages/0/321/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/321/Dialogue/enemy29
+\\C[10]The ones who caused the Genocide timeline, who
+bear the mistakes of their Interveners\\C[0], decided
+risk their very existences by fighting him.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -322,8 +399,12 @@
 
 \\C[10]その道を選んだ『介入者』の罪と一緒に
 アバドーンの身体をかき乱して、僕たちにチャンスを作ってる
-> CONTEXT: Map530/events/7/pages/0/326/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/326/Dialogue/enemy29
+Though they themselves weren't to blame, \\C[10]with
+tears in their eyes they took the sins of the
+Interveners who had decided their path, and used
+them to throw Abaddon's body into disarray.
+They bought us a chance.#RonIffyWording
 > END STRING
 
 > BEGIN STRING
@@ -331,14 +412,17 @@
 
 アバドーンを倒したら、\\C[10]彼ら\\C[0]はどうなるんだ…！
 『世界を直す権限』とやらで、助けられるのか…！？
-> CONTEXT: Map530/events/7/pages/0/331/Dialogue/kazuya < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/331/Dialogue/kazuya
+What will happen to them when we defeat Abaddon?!
 
+Can you use that "authority to fix the world" or
+whatever to save them?!#Ron
 > END STRING
 
 > BEGIN STRING
 ……………………………\\C[2]無理だよ。
-> CONTEXT: Map530/events/7/pages/0/337/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/337/Dialogue/enemy29
+......\\C[2]I'm afraid not.
 > END STRING
 
 > BEGIN STRING
@@ -346,16 +430,22 @@
 
 オールドワンに『ウボ＝サスラ』に変えられた彼らを
 元に戻すだけなら、可能なんだけどね……
-> CONTEXT: Map530/events/7/pages/0/339/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/339/Dialogue/enemy29
+Like I said during the Tea Party, \\C[2]that's an
+isolated world line. Though it'd be possible to
+change the ones turned into Ubbo-Sathlas by the
+Old One back to their normal selves.#Ron
 > END STRING
 
 > BEGIN STRING
 そして今、彼らは自ら、\\C[2]消滅する道\\C[0]を選んだ……
 
 だから………アバドーンを倒せば………
-> CONTEXT: Map530/events/7/pages/0/344/Dialogue/enemy29 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/344/Dialogue/enemy29
+Also, their choice to destroy themselves was made
+of their own volition.
 
+So... even if we defeat Abaddon...#Ron
 > END STRING
 
 > BEGIN STRING
@@ -363,8 +453,11 @@
 今のアバドーンは、僕たちを見失っている。
 
 \\C[2]このまま静かに近付けば、十分に勝機はある
-> CONTEXT: Map530/events/7/pages/0/357/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/357/Dialogue/enemy29
+But still... this is our chance.
+The way he is now, Abaddon's lost track of us.
+\\C[2]We'll have a decent chance at winning if we
+sneak up to him quietly\\C[0].#Ron
 > END STRING
 
 > BEGIN STRING
@@ -372,16 +465,21 @@
 一人残らず消滅してしまうだろうけど……
 
 ここで仕損じると、全てが無駄になってしまう……
-> CONTEXT: Map530/events/7/pages/0/362/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/362/Dialogue/enemy29
+While we fight him, those \\C[10]other versions of you\\C[0]
+will be destroying themselves inside his body.
+Everything they've done will have been for nothing
+if we mess up here.#Ron
 > END STRING
 
 > BEGIN STRING
 \\C[10]彼ら\\C[0]が命を犠牲にして作ってくれたチャンス……
 
 みすみす逃すわけにはいかないよ、\\N[1]くん。
-> CONTEXT: Map530/events/7/pages/0/367/Dialogue/enemy29 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/367/Dialogue/enemy29
+This is a chance created through \\C[10]their \\C[0]sacrifice.
 
+We can't let this slip through our fingers.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -389,8 +487,11 @@
 \\C[2]犠牲になんかさせない。
 
 彼らも、助ける。
-> CONTEXT: Map530/events/7/pages/0/374/Dialogue/kazuya-b < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/374/Dialogue/kazuya-b
+No...
+\\C[2]I won't let them sacrifice themselves.
 
+I'll save them too.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -398,8 +499,11 @@
 さっきの話、聞いてた！？
 
 そんな短時間でアバドーンを倒すことなんで無理だってば！
-> CONTEXT: Map530/events/7/pages/0/382/Dialogue/enemy29 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/382/Dialogue/enemy29
+Hold on!! Didn't you hear what I said?!!
 
+There's no way we can destroy Abaddon in such a
+short space of time!#Ron
 > END STRING
 
 > BEGIN STRING
@@ -407,8 +511,11 @@
 アバドーンは別に弱体化したってワケじゃないんだ！
 
 むしろ暴れ狂ってるから、正面からは挑めない！
-> CONTEXT: Map530/events/7/pages/0/387/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/387/Dialogue/enemy29
+Just because he's changed into that form doesn't
+mean that he's particularly weak now! In fact,
+we can't even take him head-on now that he's
+going berserk!#Ron
 > END STRING
 
 > BEGIN STRING
@@ -416,8 +523,11 @@
 取り返しのつかないことになっちゃう！
 
 彼らどころか、キミたちの世界も危ういんだよ！？
-> CONTEXT: Map530/events/7/pages/0/392/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/392/Dialogue/enemy29
+Now only that, but if we mess up because we're
+too impatient, we might end up doing something
+we can't undo! All of your worlds are in much
+more danger than them!!#Ron
 > END STRING
 
 > BEGIN STRING
@@ -425,8 +535,11 @@
 
 彼らは、あんなところで消えたいなんて思ってない！
 たとえどんなに、自分に絶望していようとも……！
-> CONTEXT: Map530/events/7/pages/0/398/Dialogue/kazuya-b < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/398/Dialogue/kazuya-b
+They don't want to disappear in a place like that!
+They wouldn't think that way no matter how much
+despair they feel! I know that because they're
+"me"!#Ron
 > END STRING
 
 > BEGIN STRING
@@ -434,16 +547,22 @@
 
 \\C[10]「自分のせいじゃない」と吐き捨てた介入者に代わって
 自分自身の犯した罪と……！
-> CONTEXT: Map530/events/7/pages/0/403/Dialogue/kazuya-b < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/403/Dialogue/kazuya-b
+They're fighting...
 
+\\C[10]Fighting the sins they bear in place of the
+Interveners who abdicated all responsibility!#Ron
 > END STRING
 
 > BEGIN STRING
 頼む……！どんな方法でもいい……
 
 彼らを……あの僕たちを助ける方法はないのか…！？
-> CONTEXT: Map530/events/7/pages/0/408/Dialogue/kazuya-b < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/408/Dialogue/kazuya-b
+Please! I don't care what it takes...
 
+Is there really no way to save them? No way at
+all?!#Ron
 > END STRING
 
 > BEGIN STRING
@@ -451,8 +570,11 @@
 
 あの時の彼の口ぶり……悲しそうっていうより……
 なんだかとても震えてた………
-> CONTEXT: Map530/events/7/pages/0/414/Dialogue/ruka_fc1 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/414/Dialogue/ruka_fc1
+I feel the same way.
 
+The way they talked... it wasn't sad...
+It sounded more like they were trembling...#Ron
 > END STRING
 
 > BEGIN STRING
@@ -460,16 +582,21 @@
 \\C[2]すごく死ぬことを怖がってた気がしたんだ……\\C[0]
 
 さっきの\\N[1]の言葉で、確信が持てたよ。
-> CONTEXT: Map530/events/7/pages/0/419/Dialogue/ruka_fc1 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/419/Dialogue/ruka_fc1
+It didn't feel like regret or despair...
+\\C[2]But like they were terrified of dying\\C[0]...
 
+So I believe what \\N[1] said just now.#Ron
 > END STRING
 
 > BEGIN STRING
 だから、もしできるなら、僕もその方法を試したい。
 
 何か方法はないの？チェシャ……
-> CONTEXT: Map530/events/7/pages/0/424/Dialogue/ruka_fc1 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/424/Dialogue/ruka_fc1
+So if possible, I also want to try saving them...
 
+Isn't there something we can do, Cheshire?#Ron
 > END STRING
 
 > BEGIN STRING
@@ -477,8 +604,11 @@
 \\C[2]方法が無いことはないよ。
 
 ボクがこの身体に戻った今なら、ね。
-> CONTEXT: Map530/events/7/pages/0/430/Dialogue/enemy29 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/430/Dialogue/enemy29
+......
 
+\\C[2]Now that I have my body back, there's nothing I
+can't do.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -486,8 +616,11 @@
 
 \\C[2]３人の力が……いや、みんなの協力が必要不可欠だ……
 でもそれでも、失敗の可能性すらある……
-> CONTEXT: Map530/events/7/pages/0/435/Dialogue/enemy29 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/435/Dialogue/enemy29
+But this'll come with a pretty big risk...
 
+\\C[2]We'll need absolutely everyone to pull this off.
+And it still might not work anyway.#RonLocalization
 > END STRING
 
 > BEGIN STRING
@@ -495,8 +628,11 @@
 
 \\N[1]くんに
 自分たちの世界の明日を任せる覚悟は出来てる？
-> CONTEXT: Map530/events/7/pages/0/440/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/440/Dialogue/enemy29
+Are all of you really okay with this? You're not
+going to have second thoughts? Are you all
+prepared to entrust the future of your worlds
+to \\N[1]-kun?#Ron
 > END STRING
 
 > BEGIN STRING
@@ -504,8 +640,11 @@
 
 \\N[1]くんが危険な目に遭うのは怖いけど…
 それで\\N[1]くんが救われるっていうなら！
-> CONTEXT: Map530/events/7/pages/0/446/Dialogue/enemy15 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/446/Dialogue/enemy15
+Of course I'll help!
 
+I'm scared of putting \\N[1]-kun in danger,
+but I'm okay with it if it means saving him!#Ron
 > END STRING
 
 > BEGIN STRING
@@ -513,22 +652,28 @@
 
 こいつも一度言い出したら聞かんからな。
 とことん付き合ってやるか……
-> CONTEXT: Map530/events/7/pages/0/452/Dialogue/alice_fc5 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/452/Dialogue/alice_fc5
+I won't object if Luka's prepared to say all that.
 
+He won't listen to anyone once he's set his mind
+on something. I'll follow you until the end.#Ron
 > END STRING
 
 > BEGIN STRING
 …………お前はどうだ？ミズキ……
-> CONTEXT: Map530/events/7/pages/0/457/Dialogue/enemy37 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/457/Dialogue/enemy37
+What will you do, Mizuki?#Ron
 > END STRING
 
 > BEGIN STRING
 この流れで、イヤとは言えないでしょうが……
 
 私は、弟が無事ならそれでいいのよ……
-> CONTEXT: Map530/events/7/pages/0/460/Dialogue/enemy38 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/460/Dialogue/enemy38
+The way everyone's talking, there's no way I could
+say no.
 
+I'm fine with it if it means saving my brother.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -536,8 +681,11 @@
 イチかバチかに賭けてみるのも悪くないわ。
 
 全力でやってやろうじゃないの！
-> CONTEXT: Map530/events/7/pages/0/464/Dialogue/enemy38 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/464/Dialogue/enemy38
+But if there's a world and a lot of people in it
+who can be saved as well, it's not a bad idea to
+put it all on a sink-or-swim plan. Let's give
+this everything we've got!#Ron
 > END STRING
 
 > BEGIN STRING
@@ -545,46 +693,58 @@
 我が否定的なことを言っても聞かぬであろう。
 
 ならばそれに応え、我も悔いを残さず、全力で臨むだけだ。
-> CONTEXT: Map530/events/7/pages/0/472/Dialogue/enemy35 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/472/Dialogue/enemy35
+Marion's also made up his mind so he wouldn't
+listen to me even if I tried to oppose the idea.
+In which case I'll respond to that by giving this
+everything I've got with no regrets.#Ron
 > END STRING
 
 > BEGIN STRING
 みんな……
 
 ありがとう…！
-> CONTEXT: Map530/events/7/pages/0/482/Dialogue/kazuya < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/482/Dialogue/kazuya
+Thank you... everyone!#Ron
 > END STRING
 
 > BEGIN STRING
 それじゃあ、準備はいいかい？\\N[1]くん。
 
 時間が無いから、作戦は一度しか言わないからね。
-> CONTEXT: Map530/events/7/pages/0/492/Dialogue/enemy29 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/492/Dialogue/enemy29
+Well then, are you ready, \\N[1]-kun?
 
+We don't have much time, so I'll only go over
+the plan once.#Ron
 > END STRING
 
 > BEGIN STRING
 今のキミの身体は、いわゆる『アバター』だ。
 
 \\C[2]ボクが『脱出直前のキミ』を模して創り上げた肉体……
-> CONTEXT: Map530/events/7/pages/0/496/Dialogue/enemy29 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/496/Dialogue/enemy29
+Your body right now is a so-called "avatar".
 
+\\C[2]It's one I created using your body from just
+before you escaped the town as a base.#Ron
 > END STRING
 
 > BEGIN STRING
 だから、キミの身体には\\C[2]『天使の魔力』\\C[0]が宿ってる。
 
 それを………今から\\C[10]『意図的に暴走させる』\\C[0]
-> CONTEXT: Map530/events/7/pages/0/500/Dialogue/enemy29 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/500/Dialogue/enemy29
+That means your body still has the \\C[2]angelic magic
+\\C[0]inside it, so we'll make use of it...
 
+\\C[10]By intentionally making it go out of control.
 > END STRING
 
 > BEGIN STRING
 \\{\\{えっ！？
-> CONTEXT: Map530/events/7/pages/0/505/Dialogue/kazuya < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/505/Dialogue/kazuya
+\\{\\{Huh?!#Ron
 > END STRING
 
 > BEGIN STRING
@@ -592,8 +752,11 @@
 キミは無差別に暴走して、アバドーンと同じ破壊者になる。
 
 でも、今は\\C[2]ルカくんとマリオンくんがいる
-> CONTEXT: Map530/events/7/pages/0/507/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/507/Dialogue/enemy29
+Naturally, that'll turn you into Samael, a
+rampaging, indiscriminate engine of destruction
+just like Abaddon. But we've got \\C[2]Luka-kun and
+Marion-kun with us now\\C[0].#Ron
 > END STRING
 
 > BEGIN STRING
@@ -601,8 +764,11 @@
 
 \\C[2]あれは『天使の魔力』で繋げているから
 キミが暴走しても、他の二人がその魔力を制御できる。
-> CONTEXT: Map530/events/7/pages/0/512/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/512/Dialogue/enemy29
+Remember that mark I put on your hands?
+\\C[2]Because that's linked to your angelic magic,
+those two will be able to control it even while
+you're rampaging.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -610,16 +776,20 @@
 
 \\C[0]それで完全に魔力に呑み込まれてしまう前に
 キミがアバドーンを倒せば、万事解決ってワケ。
-> CONTEXT: Map530/events/7/pages/0/517/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/517/Dialogue/enemy29
+Even say... \\C[2]pulling your "reins" back\\C[0]...
+Then all you have to do is defeat Abaddon before
+you completely lose yourself and everything will
+be neatly resolved.#Ron
 > END STRING
 
 > BEGIN STRING
 …………それで…
 
 \\C[2]僕が天使の魔力の暴走に耐えられる時間は…？
-> CONTEXT: Map530/events/7/pages/0/523/Dialogue/kazuya < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/523/Dialogue/kazuya
+So... \\C[2]how long will I be able to endure the
+angelic magic going berserk?#Ron
 > END STRING
 
 > BEGIN STRING
@@ -627,8 +797,11 @@
 
 大丈夫、以前キミが見たサマエルの暴走は不完全なもので
 \\C[2]今回のヤツの火力は桁が違う
-> CONTEXT: Map530/events/7/pages/0/527/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/527/Dialogue/enemy29
+Let's see... \\C[10]not for very long\\C[0].
+But don't worry, compared to the incomplete Samael
+you saw last time, \\C[2]this one's firepower will be
+only a completely different level\\C[0].#Ron
 > END STRING
 
 > BEGIN STRING
@@ -636,8 +809,11 @@
 \\C[2]ボクも他のみんなの火力サポートが出来るようになった
 
 どちらに転ぶにせよ、決着は短い時間で済むと思うよ。
-> CONTEXT: Map530/events/7/pages/0/532/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/532/Dialogue/enemy29
+And on top of that, thanks to being back in my
+own body, \\C[2]I can now use everyone else's attack
+support skills. However it turns out, I think
+this'll be over quick.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -645,8 +821,11 @@
 
 \\N[1]くんが戦っている間に、残り二人がやられても
 \\C[10]その時点で制御を失って、アウトだよ。
-> CONTEXT: Map530/events/7/pages/0/537/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map530/events/7/pages/0/537/Dialogue/enemy29
+\\C[2]But the scariest thing here is going to be
+the power of Samael's rampage. If the other two
+go down while you're fighting, \\C[10]they'll lose
+control of you, and it'll be all over\\C[0].#Ron
 > END STRING
 
 > BEGIN STRING
@@ -654,24 +833,32 @@
 ルカやマリオンがやられてもダメ……というわけだな。
 
 こちらの護衛は任せておけ。
-> CONTEXT: Map530/events/7/pages/0/542/Dialogue/alice_fc5 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/542/Dialogue/alice_fc5
+So in other words, we can't let either Luka or
+Marion be defeated.
 
+You leave protecting them to us.#Ron
 > END STRING
 
 > BEGIN STRING
 我ら天使が務めである『人の守護』……
 
 今こそ、その真価を見せるときだ…！！
-> CONTEXT: Map530/events/7/pages/0/547/Dialogue/enemy35 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/547/Dialogue/enemy35
+Our duty as angels is to protect humans...
 
+This will be where I demonstrate the true value
+of that duty!!#Ron
 > END STRING
 
 > BEGIN STRING
 チェシャ………始めてくれ。
 
 覚悟は……出来てる！
-> CONTEXT: Map530/events/7/pages/0/556/Dialogue/kazuya < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/556/Dialogue/kazuya
+Cheshire... let's start.
 
+I'm... ready!#Ron
 > END STRING
 
 > BEGIN STRING
@@ -679,38 +866,50 @@
 
 ちゃんと正気を保ってね……
 かなりキツいはずだから……
-> CONTEXT: Map530/events/7/pages/0/563/Dialogue/enemy29 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/563/Dialogue/enemy29
+Here I go, \\N[1]-kun...
 
+Hold on to your sanity...
+This is going to be pretty rough...#Ron
 > END STRING
 
 > BEGIN STRING
 さぁ……\\|
 
 ゆっくりと意識を集中させて、\\|\\N[1]くん\\|\\|\\^
-> CONTEXT: Map530/events/7/pages/0/590/Dialogue/enemy29 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/590/Dialogue/enemy29
+Now...\\|
 
+Slowly focus your mind, \\|\\N[1]-kun...\\|\\|\\^
 > END STRING
 
 > BEGIN STRING
 \\N[1]……！！
 
 その姿は…！！？\\|\\|\\^
-> CONTEXT: Map530/events/7/pages/0/605/Dialogue/alice_fc5 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/605/Dialogue/alice_fc5
+\\N[1]...!!
 
+What's that form?!!\\|\\|\\^#Ron
 > END STRING
 
 > BEGIN STRING
 ほう………これは興味深い\\|\\^
 
 \\C[2]サマエルの力を鎧として纏ったのか……\\|\\|\\^
-> CONTEXT: Map530/events/7/pages/0/609/Dialogue/enemy34 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/609/Dialogue/enemy34
+Hooh, how fascinating.\\|\\^
 
+\\C[2]Samael's power has coiled around him as armor.\\|\\|\\^#Ron
 > END STRING
 
 > BEGIN STRING
 \\C[10]世界を救うために、アバドーンの世界を壊す……\\|\\|
 
 今こそキミ自身が『世界の破壊者』になる時だ…！！！\\|\\|\\|\\|\\^
-> CONTEXT: Map530/events/7/pages/0/614/Dialogue/enemy29 < UNTRANSLATED
+> CONTEXT: Map530/events/7/pages/0/614/Dialogue/enemy29
+\\C[10]Destroy Abaddon's world to save your own...\\|\\|
 
+Now is the time for you to become the "Destroyer
+of Worlds"!!!\\|\\|\\|\\|\\^#Ron
 > END STRING

--- a/Gaijinizer patch/Map531.txt
+++ b/Gaijinizer patch/Map531.txt
@@ -1,54 +1,64 @@
 ﻿> GAIJINIZER PATCH FILE
 > BEGIN STRING
 ？？？「目を覚まして……」
-> CONTEXT: Map531/events/1/pages/0/16/Dialogue < UNTRANSLATED
-
+> CONTEXT: Map531/events/1/pages/0/16/Dialogue
+??? 「Wake up...」#Ron
 > END STRING
 
 > BEGIN STRING
 ちゃんと起きて……
 
 もう悪夢は……終わったから……
-> CONTEXT: Map531/events/1/pages/0/37/Dialogue/other7 < UNTRANSLATED
+> CONTEXT: Map531/events/1/pages/0/37/Dialogue/other7
+Make sure you wake up...
 
+Your nightmare... is over now...#Ron
 > END STRING
 
 > BEGIN STRING
 き……きみ……は……？
-> CONTEXT: Map531/events/1/pages/0/41/Dialogue/kazuya-d < UNTRANSLATED
-
+> CONTEXT: Map531/events/1/pages/0/41/Dialogue/kazuya-d
+W...Who... are you...?#Ron
 > END STRING
 
 > BEGIN STRING
 わたし、\\C[2]レイナ\\C[0]っていうの
 
 はじめまして……
-> CONTEXT: Map531/events/1/pages/0/43/Dialogue/other7 < UNTRANSLATED
+> CONTEXT: Map531/events/1/pages/0/43/Dialogue/other7
+I'm called \\C[2]Reina\\C[0]...
 
+Nice to meet you.#Ron
 > END STRING
 
 > BEGIN STRING
 あなたが泣いてる声がしたから………
 
 心配になって、見に来ちゃった。
-> CONTEXT: Map531/events/1/pages/0/47/Dialogue/other7 < UNTRANSLATED
+> CONTEXT: Map531/events/1/pages/0/47/Dialogue/other7
+I was worried because I heard you crying...
 
+So I came in to check on you.#Ron
 > END STRING
 
 > BEGIN STRING
 どうしたの？誰かにいじめられた？
 
 困ったことがあったら、私に言ってね？
-> CONTEXT: Map531/events/1/pages/0/51/Dialogue/other7 < UNTRANSLATED
+> CONTEXT: Map531/events/1/pages/0/51/Dialogue/other7
+Are you okay? No one's been bullying you?
 
+You can tell me if something's bothering you.#Ron
 > END STRING
 
 > BEGIN STRING
 悪夢………そうだ……
 
 僕は……ずっと……夢を見ていた……
-> CONTEXT: Map531/events/1/pages/0/57/Dialogue/kazuya-d < UNTRANSLATED
+> CONTEXT: Map531/events/1/pages/0/57/Dialogue/kazuya-d
+A nightmare... I see...
 
+It was... all... a long dream...#Ron
 > END STRING
 
 > BEGIN STRING
@@ -56,8 +66,11 @@
 
 きみは………僕を恨んでいないのか……？
 償わなくちゃ………全部……
-> CONTEXT: Map531/events/1/pages/0/61/Dialogue/kazuya-d < UNTRANSLATED
+> CONTEXT: Map531/events/1/pages/0/61/Dialogue/kazuya-d
+No... the nightmare... isn't over...
 
+Don't you... resent me...?
+I have to atone... for everything...#Ron
 > END STRING
 
 > BEGIN STRING
@@ -65,8 +78,11 @@
 
 私にも、手伝わせて？
 あなたの気が済む時まで、ずっとあなたの側にいるから…。
-> CONTEXT: Map531/events/1/pages/0/67/Dialogue/other7 < UNTRANSLATED
+> CONTEXT: Map531/events/1/pages/0/67/Dialogue/other7
+You don't have to bear everything alone...
 
+Let me help, okay?
+I'll stay by your side until you find peace.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -74,24 +90,30 @@
 
 でも、あなたなら………
 私の知っているあなたなら、きっとやり直せる……
-> CONTEXT: Map531/events/1/pages/0/72/Dialogue/other7 < UNTRANSLATED
-
+> CONTEXT: Map531/events/1/pages/0/72/Dialogue/other7
+It might take a long time... but knowing you...
+knowing the person you are... I'm sure you'll
+be able to start over.#RonIffyWording
 > END STRING
 
 > BEGIN STRING
 だから……悲しまないで……
 
 一緒に生きよう？
-> CONTEXT: Map531/events/1/pages/0/77/Dialogue/other7 < UNTRANSLATED
+> CONTEXT: Map531/events/1/pages/0/77/Dialogue/other7
+So don't be sad...
 
+Let's live on together...#Ron
 > END STRING
 
 > BEGIN STRING
 ……………彼は……
 
 この世界の僕は、やり直せるだろうか……？
-> CONTEXT: Map531/events/1/pages/0/87/Dialogue/kazuya < UNTRANSLATED
+> CONTEXT: Map531/events/1/pages/0/87/Dialogue/kazuya
+Can he... can this world's me...
 
+Really start over?#Ron
 > END STRING
 
 > BEGIN STRING
@@ -99,8 +121,11 @@
 
 \\C[10]『その道に進んだ介入者』\\C[0]のせいとはいえ、
 彼自身が犯した人殺しの罪が消えるわけじゃない……
-> CONTEXT: Map531/events/1/pages/0/92/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map531/events/1/pages/0/92/Dialogue/enemy29
+This sounds harsh, but it might be hopeless...
+Though \\C[10]it was the fault of the Intervener who
+lead him down that path\\C[0], that doesn't absolve
+him of the sin of murder he committed.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -108,16 +133,24 @@
 そのうえで、自分自身と向き合っていかなきゃならない……
 
 普通の生活さえ、きっととても長い年月がかかるだろう…
-> CONTEXT: Map531/events/1/pages/0/97/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map531/events/1/pages/0/97/Dialogue/enemy29
+From here he'll be taking whatever punishments he
+gets from the military and courts, getting
+psychiatric treatment, and having to come to grips
+with his own self.
+It'll probably take him a very long time before
+he can have anything approaching a normal life.#Ron
 > END STRING
 
 > BEGIN STRING
 でも………なんでだろうな……
 
 \\C[2]『きっと大丈夫』\\C[0]って、根拠のない確信がある……
-> CONTEXT: Map531/events/1/pages/0/105/Dialogue/enemy29 < UNTRANSLATED
+> CONTEXT: Map531/events/1/pages/0/105/Dialogue/enemy29
+But though I don't have anything to base it on...
 
+It kind of feels like \\C[2]things will work out for
+him \\C[2]somehow...#Ron
 > END STRING
 
 > BEGIN STRING
@@ -125,16 +158,20 @@
 
 キミにだったら、どんな不可能と思えることも出来てしまう…
 そんな気がするよ……
-> CONTEXT: Map531/events/1/pages/0/109/Dialogue/enemy29 < UNTRANSLATED
+> CONTEXT: Map531/events/1/pages/0/109/Dialogue/enemy29
+I mean, he's \\N[1]-kun, after all.
 
+I get the feeling that nothing's impossible when
+it comes to you...#Ron
 > END STRING
 
 > BEGIN STRING
 そうだ、百鬼……！！
 
 ルシィや、ティタノボアやニーナたちは……！？
-> CONTEXT: Map531/events/1/pages/0/118/Dialogue/kazuya < UNTRANSLATED
-
+> CONTEXT: Map531/events/1/pages/0/118/Dialogue/kazuya
+Oh yeah, what about Hyakki, Lucy, Titanoboa,
+Nina, and the others...?!#Ron
 > END STRING
 
 > BEGIN STRING
@@ -142,8 +179,11 @@
 
 \\C[2]アバドーンが倒されてから、真っ先に直したよ。
 ミズキちゃんの世界もね。
-> CONTEXT: Map531/events/1/pages/0/122/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map531/events/1/pages/0/122/Dialogue/enemy29
+Naturally, they're all safe and sound. \\C[2]With
+Abaddon defeated, they've all been restored to
+just before they were devoured. And that goes for
+Mizuki-chan's world, too.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -151,8 +191,11 @@
 
 今回の状況的に、仕方がなかったって事で
 なんとかお咎めなしにしてもらった。
-> CONTEXT: Map531/events/1/pages/0/127/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map531/events/1/pages/0/127/Dialogue/enemy29
+It was a bit of work to get Hyakki back after her
+existence itself was almost negated, but
+considering the situation I managed to do it
+without getting harangued.#CheckLater
 > END STRING
 
 > BEGIN STRING
@@ -160,6 +203,9 @@
 
 ウボ＝サスラの侵攻も、犠牲になった命も含めて
 全て元通りに治まっているはずだよ。
-> CONTEXT: Map531/events/1/pages/0/132/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map531/events/1/pages/0/132/Dialogue/enemy29
+And by changing this timeline back to normal,
+the Ubbo-Sathla invasion and all the victims who
+lost their lives to it have been restored back
+to normal.#Ron
 > END STRING

--- a/Gaijinizer patch/Map531.txt
+++ b/Gaijinizer patch/Map531.txt
@@ -193,9 +193,9 @@ Mizuki-chan's world, too.#Ron
 なんとかお咎めなしにしてもらった。
 > CONTEXT: Map531/events/1/pages/0/127/Dialogue/enemy29
 It was a bit of work to get Hyakki back after her
-existence itself was almost negated, but
-considering the situation I managed to do it
-without getting harangued.#CheckLater
+existence itself was almost negated... but I
+managed to get it done without anyone asking
+too many questions.#Ron
 > END STRING
 
 > BEGIN STRING

--- a/Gaijinizer patch/Map532.txt
+++ b/Gaijinizer patch/Map532.txt
@@ -3,16 +3,18 @@
 少女「みんなは……？
 
 　　　こわいオバケや、お姉ちゃんたちは……？」
-> CONTEXT: Map532/events/27/pages/0/15/Dialogue < UNTRANSLATED
-
+> CONTEXT: Map532/events/27/pages/0/15/Dialogue
+Girl 「Where did the monsters and those ladies go?」#Ron
 > END STRING
 
 > BEGIN STRING
 大丈夫だよ、もう安心だ。
 
 怖いのはオジさんたちがぜーんぶ追い払ったからな？
-> CONTEXT: Map532/events/27/pages/0/19/Dialogue/other8 < UNTRANSLATED
+> CONTEXT: Map532/events/27/pages/0/19/Dialogue/other8
+It's okay, you're safe now.
 
+Me and this guy drove them all away.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -20,8 +22,11 @@
 
 どういうわけか、俺らが無事だって確認すると
 みんなどっか行っちまったのさ。
-> CONTEXT: Map532/events/27/pages/0/23/Dialogue/other8 < UNTRANSLATED
+> CONTEXT: Map532/events/27/pages/0/23/Dialogue/other8
+Those demon girls are safe, too.
 
+They went off somewhere for some reason after
+making sure we were safe.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -29,8 +34,10 @@
 どういうことだ…？
 
 あそこまできて、全部ただの幻覚、って事はないだろうが…
-> CONTEXT: Map532/events/27/pages/0/32/Dialogue/other8 < UNTRANSLATED
-
+> CONTEXT: Map532/events/27/pages/0/32/Dialogue/other8
+Forget the monsters, even those strange holes
+have gone. What happened? Don't tell me all this
+was just one big hallucination...#Ron
 > END STRING
 
 > BEGIN STRING
@@ -38,8 +45,10 @@
 
 俺らを攻撃すらせず、立ち去っていくとはな……
 戦争中だというのに、おかしな連中だ。
-> CONTEXT: Map532/events/27/pages/0/37/Dialogue/other8 < UNTRANSLATED
-
+> CONTEXT: Map532/events/27/pages/0/37/Dialogue/other8
+And those demon bastards... they left without even
+attacking us. What a strange bunch acting like
+that when we're in the middle of a war.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -47,8 +56,10 @@
 争わずに済むなら、それに越したことはないっすよ。
 
 ユウマ隊長も、口癖みたいに言ってるでしょ。
-> CONTEXT: Map532/events/27/pages/0/45/Dialogue/other8 < UNTRANSLATED
-
+> CONTEXT: Map532/events/27/pages/0/45/Dialogue/other8
+Hey, don't get your panties in a bunch. It's
+like Captain Yuuma's always saying, them leaving
+without a fight is the best possible outcome.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -56,8 +67,11 @@
 
 もし縁があるようなら、俺もああいう子たちと
 お近づきになりたいもんっすねぇ
-> CONTEXT: Map532/events/27/pages/0/50/Dialogue/other8 < UNTRANSLATED
+> CONTEXT: Map532/events/27/pages/0/50/Dialogue/other8
+And come on... they were pretty hot.
 
+I wouldn't mind getting cozy with those girls if
+I ever get the chance.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -65,14 +79,20 @@
 
 ……行くぞ。ここから港までは徒歩だ。
 まだ安心はできんからな。
-> CONTEXT: Map532/events/27/pages/0/55/Dialogue/other8 < UNTRANSLATED
+> CONTEXT: Map532/events/27/pages/0/55/Dialogue/other8
+Hmph, you've got weird taste.
 
+Come on, we'll head to the harbor on foot.
+We've still got to secure her safety.#Ron
 > END STRING
 
 > BEGIN STRING
 お前は引き続き、そのガキをちゃんと守っていろ。
 
 今度は、悪魔の手を借りんでもいいようにしたいもんだ…
-> CONTEXT: Map532/events/27/pages/0/60/Dialogue/other8 < UNTRANSLATED
+> CONTEXT: Map532/events/27/pages/0/60/Dialogue/other8
+You keep protecting the kid.
 
+I hope we don't have to rely on demon help
+this time.#Ron
 > END STRING

--- a/Gaijinizer patch/Map532.txt
+++ b/Gaijinizer patch/Map532.txt
@@ -26,7 +26,7 @@ Me and this guy drove them all away.#Ron
 Those demon girls are safe, too.
 
 They went off somewhere for some reason after
-making sure we were safe.#Ron
+making sure we were okay.#Ron
 > END STRING
 
 > BEGIN STRING

--- a/Gaijinizer patch/Map533.txt
+++ b/Gaijinizer patch/Map533.txt
@@ -3,29 +3,34 @@
 ね、ねえ………
 
 そろそろマズくない……？
-> CONTEXT: Map533/events/3/pages/0/11/Dialogue/enemy27 < UNTRANSLATED
+> CONTEXT: Map533/events/3/pages/0/11/Dialogue/enemy27
+H-Hey...
 
+Isn't this getting pretty bad?#Ron
 > END STRING
 
 > BEGIN STRING
 シッ、マイちゃん……
 
 静かに……
-> CONTEXT: Map533/events/3/pages/0/15/Dialogue/enemy30 < UNTRANSLATED
+> CONTEXT: Map533/events/3/pages/0/15/Dialogue/enemy30
+Mai-chan, shh...
 
+Pipe down...#Ron
 > END STRING
 
 > BEGIN STRING
 \\{\\{\\{あいむ、ちゃんぴおーん！
-> CONTEXT: Map533/events/3/pages/0/39/Dialogue/enemy32 < UNTRANSLATED
-
+> CONTEXT: Map533/events/3/pages/0/39/Dialogue/enemy32
+\\{\\{\\{I'M THE CHAMPION!#Ron
 > END STRING
 
 > BEGIN STRING
 \\{\\{みんなーーーー
 もう出てきて大丈夫だよーーーー！
-> CONTEXT: Map533/events/3/pages/0/41/Dialogue/enemy32 < UNTRANSLATED
-
+> CONTEXT: Map533/events/3/pages/0/41/Dialogue/enemy32
+\\{\\{You can all come
+out now!#Ron
 > END STRING
 
 > BEGIN STRING
@@ -33,15 +38,18 @@
 
 仕方なく私の宝玉を使わせていますが……
 それは本来、貴方のようなバカが持つものではないのですよ！
-> CONTEXT: Map533/events/3/pages/0/44/Dialogue/enemy28 < UNTRANSLATED
-
+> CONTEXT: Map533/events/3/pages/0/44/Dialogue/enemy28
+Hey!! If you're done, then hurry up and get back
+here. I had no choice but you let you use my gem,
+but it doesn't belong to an idiot like you!#Ron
 > END STRING
 
 > BEGIN STRING
 \\{\\{やだーーーーー！
 あと５分ーーーーー！！
-> CONTEXT: Map533/events/3/pages/0/49/Dialogue/enemy32 < UNTRANSLATED
-
+> CONTEXT: Map533/events/3/pages/0/49/Dialogue/enemy32
+\\{\\{No way!
+Five more minutes!!
 > END STRING
 
 > BEGIN STRING
@@ -49,14 +57,17 @@
 一時はどうなることかと思ったけど……
 
 まさか俺様の過去のイタズラが切り札になっちまうとは……
-> CONTEXT: Map533/events/3/pages/0/52/Dialogue/enemy31 < UNTRANSLATED
-
+> CONTEXT: Map533/events/3/pages/0/52/Dialogue/enemy31
+Haaaah... I didn't know what was going to
+happen there for a minute, but I never thought
+my little prank from before would turn into the
+ace up our sleeve.#Ron
 > END STRING
 
 > BEGIN STRING
 スフィンクスちゃん………
 
 楽しそう……♪
-> CONTEXT: Map533/events/3/pages/0/57/Dialogue/enemy27 < UNTRANSLATED
-
+> CONTEXT: Map533/events/3/pages/0/57/Dialogue/enemy27
+Sphinx-chan looks like she's having fun. ♪#Ron
 > END STRING

--- a/Gaijinizer patch/Map534.txt
+++ b/Gaijinizer patch/Map534.txt
@@ -3,8 +3,10 @@
 ねぇ\\N[1]くん……
 
 \\C[10]『諦めない』\\C[0]って、\\C[2]場合によってはとても残酷なんだ。
-> CONTEXT: Map534/events/1/pages/0/5/Dialogue/enemy29 < UNTRANSLATED
+> CONTEXT: Map534/events/1/pages/0/5/Dialogue/enemy29
+Hey, \\N[1]-kun...
 
+\\C[10]never giving up \\C[2]can be really cruel sometimes...#Ron
 > END STRING
 
 > BEGIN STRING
@@ -12,8 +14,10 @@
 他のもののチャンスを逃してしまうことだってあるし
 
 諦めること自体が、その人の救いになることだってある。
-> CONTEXT: Map534/events/1/pages/0/9/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map534/events/1/pages/0/9/Dialogue/enemy29
+Never giving up on absolutely anything can mean
+missing out on chances. Sometimes, giving up is
+the only thing you can do to help.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -21,8 +25,11 @@
 
 きっと今のキミ自体も存在しなかっただろうし
 病室にいる方のキミも、存在自体が消えていただろう……
-> CONTEXT: Map534/events/1/pages/0/14/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map534/events/1/pages/0/14/Dialogue/enemy29
+But if you'd given up even once half-way through,
+you yourself wouldn't exist here now, and the you
+in that hospital room would've disappeared as
+well.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -30,8 +37,11 @@
 そのほとんどが、彼を簡単に見放したから……
 
 キミの行動と言葉で、ボクの気持ちも少しは軽くなった……
-> CONTEXT: Map534/events/1/pages/0/19/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map534/events/1/pages/0/19/Dialogue/enemy29
+Most of the \\C[10]Interveners who became the Old One's
+pawns \\C[0]did so because they abandoned him... Even
+I took your words and actions lightly to an
+extent...#Ron
 > END STRING
 
 > BEGIN STRING
@@ -39,8 +49,11 @@
 オールドワンに心酔しきった介入者たちは変わらないんだろう。
 
 \\C[0]でも、キミは彼らとは真逆の、素晴らしい事を証明した。
-> CONTEXT: Map534/events/1/pages/0/24/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map534/events/1/pages/0/24/Dialogue/enemy29
+\\C[10]I'm sure there will be Interveners who adore
+the Old One who won't change even after watching
+this ending. \\C[0]But utterly unlike them, you've
+proven something wonderful.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -48,8 +61,11 @@
 
 ボクは最初から、あんなものを気にする必要はなかったんだね。
 特に、キミに関しては……
-> CONTEXT: Map534/events/1/pages/0/29/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map534/events/1/pages/0/29/Dialogue/enemy29
+From the very start, I never had any need to worry
+about them and their morbid curiosity and their
+foolish, emotional craving for bloodshed.
+Especially where you were involved...#Ron
 > END STRING
 
 > BEGIN STRING
@@ -57,20 +73,26 @@
 そんなキミの頑張りに対する、ボクの些細なプレゼント♪
 
 ……まぁ介入権限的に、これ以上のことは出来ないんだけど
-> CONTEXT: Map534/events/1/pages/0/35/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Map534/events/1/pages/0/35/Dialogue/enemy29
+So to give you a little something for all your
+hard work, I ensured the you of this timeline
+would meet her. In terms of my Intervention
+authority, it's about the best I can do. ♪#RonIffyWording
 > END STRING
 
 > BEGIN STRING
 チェシャ……。
-> CONTEXT: Map534/events/1/pages/0/40/Dialogue/kazuya < UNTRANSLATED
-
+> CONTEXT: Map534/events/1/pages/0/40/Dialogue/kazuya
+Cheshire...#Ron
 > END STRING
 
 > BEGIN STRING
 ……そろそろ、帰ろうか。
 
 ルカくんやマリオンくん、そしてみんなが心配しているよ。
-> CONTEXT: Map534/events/1/pages/0/44/Dialogue/enemy29 < UNTRANSLATED
+> CONTEXT: Map534/events/1/pages/0/44/Dialogue/enemy29
+It's about time we headed back.
 
+Marion-kun, Luka-kun, and the others will be
+getting worried.#Ron
 > END STRING

--- a/Gaijinizer patch/Map538.txt
+++ b/Gaijinizer patch/Map538.txt
@@ -1,8 +1,8 @@
 ﻿> GAIJINIZER PATCH FILE
 > BEGIN STRING
 …………どうやら、上手くいったようですね。
-> CONTEXT: Map538/events/5/pages/0/7/Dialogue/yuuma < UNTRANSLATED
-
+> CONTEXT: Map538/events/5/pages/0/7/Dialogue/yuuma
+...It seems everything went well.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -10,8 +10,10 @@
 世話が焼けるんだから、\\N[1]ってば
 
 あーんな不安そうな顔しちゃってさ。
-> CONTEXT: Map538/events/5/pages/0/10/Dialogue/enemy19 < UNTRANSLATED
-
+> CONTEXT: Map538/events/5/pages/0/10/Dialogue/enemy19
+That \\N[1], he's always needing someone to
+bail him out. He had such a worried look on his
+face.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -19,8 +21,11 @@
 あんな風にされちゃ、虚勢だって張っちゃうわよ。
 
 やっぱり、今後も私たちがしっかり支えてあげなくちゃね
-> CONTEXT: Map538/events/5/pages/0/15/Dialogue/enemy19 < UNTRANSLATED
-
+> CONTEXT: Map538/events/5/pages/0/15/Dialogue/enemy19
+Having the prospect of your existence being erased
+is scary, even for a demon. But we had to put on a
+brave face for him. We'll have to make sure we
+keep supporting him from here on out, too.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -28,16 +33,20 @@
 
 アイツは態度こそ優男で頼りないけど
 やるときはきっちり決める男さ。
-> CONTEXT: Map538/events/5/pages/0/21/Dialogue/enemy14 < UNTRANSLATED
-
+> CONTEXT: Map538/events/5/pages/0/21/Dialogue/enemy14
+Hmph! I believed in him from the start. He comes
+across as a pretty unreliable, effeminate guy,
+but he pulls through when push comes to shove.#Ron
 > END STRING
 
 > BEGIN STRING
 久々に外で思いきり暴れられて、スカッとしたよ
 
 さぁて、二階で昼寝でもするかねぇ……
-> CONTEXT: Map538/events/5/pages/0/26/Dialogue/enemy14 < UNTRANSLATED
-
+> CONTEXT: Map538/events/5/pages/0/26/Dialogue/enemy14
+It was so refreshing to cut loose outside like
+that, but I think I'll go upstairs and take a
+nap or something.#Ron
 > END STRING
 
 > BEGIN STRING
@@ -45,14 +54,17 @@
 
 こちらで「目覚めた」ときのために
 とびきりの夕食を作って待つ事にしましょう……
-> CONTEXT: Map538/events/5/pages/0/31/Dialogue/yuuma < UNTRANSLATED
+> CONTEXT: Map538/events/5/pages/0/31/Dialogue/yuuma
+Fufu, it sure was.
 
+Let's make a huge feast and wait for him to
+"wake up".#Ron
 > END STRING
 
 > BEGIN STRING
 \\N[1]………
 
 よく頑張りましたね……
-> CONTEXT: Map538/events/5/pages/0/36/Dialogue/yuuma < UNTRANSLATED
-
+> CONTEXT: Map538/events/5/pages/0/36/Dialogue/yuuma
+You've worked hard, \\N[1]...#Ron
 > END STRING

--- a/Gaijinizer patch/Skills.txt
+++ b/Gaijinizer patch/Skills.txt
@@ -11046,6 +11046,12 @@ Universal Requiem#Ron
 > END STRING
 
 > BEGIN STRING
+は全ての者への鎮魂歌を放った！
+> CONTEXT: Skills/937/message1
+ puts up his shield to defend himself!#Ron
+> END STRING
+
+> BEGIN STRING
 相手の攻撃を防ぐ体勢をとる
 > CONTEXT: Skills/937/description
 Braces for an enemy's attack.#Ron

--- a/Gaijinizer patch/Skills.txt
+++ b/Gaijinizer patch/Skills.txt
@@ -7958,7 +7958,7 @@ Sweet Boy#Ron
 > CONTEXT: Skills/665/message2
 > CONTEXT: Skills/666/message2
 > CONTEXT: Skills/667/message2
-Like his spirit, all \\N[1]'s abilities are sucked away...#afrg
+His abilities are sucked out along with his energy...#afrg/Ron
 > END STRING
 
 > BEGIN STRING
@@ -7966,7 +7966,7 @@ Like his spirit, all \\N[1]'s abilities are sucked away...#afrg
 > CONTEXT: Skills/665/name
 > CONTEXT: Skills/666/name
 > CONTEXT: Skills/667/name
-Virtue: Ayashi Ayaka#MTLed
+Exquisite Skill: Bewitching Spirit#Ron
 > END STRING
 
 > BEGIN STRING
@@ -7974,7 +7974,7 @@ Virtue: Ayashi Ayaka#MTLed
 > CONTEXT: Skills/665/message1
 > CONTEXT: Skills/666/message1
 > CONTEXT: Skills/667/message1
- hugs \\N[1] while patting his head...#afrg - incorrect?
+ is held by Daji as she gently strokes his head...#Ron
 > END STRING
 
 > BEGIN STRING
@@ -8718,22 +8718,22 @@ It's over.#Triketos
 
 > BEGIN STRING
 遐ｴ貊
-> CONTEXT: Skills/753/name < UNTRANSLATED
-> CONTEXT: Skills/942/name < UNTRANSLATED
-
+> CONTEXT: Skills/753/name
+> CONTEXT: Skills/942/name
+\\X[50]Destruction#Ron
 > END STRING
 
 > BEGIN STRING
 は、混沌のエネルギーを爆発させた！
-> CONTEXT: Skills/753/message1 < UNTRANSLATED
-> CONTEXT: Skills/942/message1 < UNTRANSLATED
-
+> CONTEXT: Skills/753/message1
+> CONTEXT: Skills/942/message1
+ detonates chaos energy!#Ron
 > END STRING
 
 > BEGIN STRING
 地獄の業火のような炎の渦が、アバドーンに襲いかかる！
-> CONTEXT: Skills/755/message2 < UNTRANSLATED
-
+> CONTEXT: Skills/755/message2
+A vortex of hellfire flies toward Abaddon!#Ron
 > END STRING
 
 > BEGIN STRING
@@ -8750,14 +8750,14 @@ Deals high physical damage to an opponent.#Ron
 
 > BEGIN STRING
 鬼炎翔龍
-> CONTEXT: Skills/755/name < UNTRANSLATED
-
+> CONTEXT: Skills/755/name
+Oni's Soaring Dragon Flame#Ron
 > END STRING
 
 > BEGIN STRING
 の傍らで、夜深は鬼炎翔龍を放った！
-> CONTEXT: Skills/755/message1 < UNTRANSLATED
-
+> CONTEXT: Skills/755/message1
+ watches on as Yami unleashes Oni's Soaring Dragon Flame!#Ron
 > END STRING
 
 > BEGIN STRING
@@ -8902,20 +8902,20 @@ Special accident battles can occur against this monster.#Strate
 
 > BEGIN STRING
 神の怒りの炎が、アバドーンの身体を貫く！
-> CONTEXT: Skills/766/message2 < UNTRANSLATED
-
+> CONTEXT: Skills/766/message2
+Godly flames of wrath pierce through Abaddon's body!#Ron
 > END STRING
 
 > BEGIN STRING
 メギドファイア
-> CONTEXT: Skills/766/name < UNTRANSLATED
-
+> CONTEXT: Skills/766/name
+Megido Fire#Ron
 > END STRING
 
 > BEGIN STRING
 の傍らで、ミズキはメギドフレイムを放った
-> CONTEXT: Skills/766/message1 < UNTRANSLATED
-
+> CONTEXT: Skills/766/message1
+ watches on as Mizuki unleashes Megido Fire!#Ron
 > END STRING
 
 > BEGIN STRING
@@ -9152,32 +9152,32 @@ Great physical damage to a single enemy.#MTLed
 
 > BEGIN STRING
 紅蓮の火炎が、アバドーンを包み込む…！！
-> CONTEXT: Skills/788/message2 < UNTRANSLATED
-
+> CONTEXT: Skills/788/message2
+Abaddon is engulfed in crimson flames!!#Ron
 > END STRING
 
 > BEGIN STRING
 ヘルハウンド・グロリア
-> CONTEXT: Skills/788/name < UNTRANSLATED
-
+> CONTEXT: Skills/788/name
+Hellhound's Gloria#Ron
 > END STRING
 
 > BEGIN STRING
 の傍らで、ミズキはオルトロスの連撃を浴びせた
-> CONTEXT: Skills/788/message1 < UNTRANSLATED
-
+> CONTEXT: Skills/788/message1
+ watches Mizuki rain down repeated attacks with Orthrus!#Ron
 > END STRING
 
 > BEGIN STRING
 氷の塊が、アバドーンを包み込み、粉砕する！
-> CONTEXT: Skills/790/message2 < UNTRANSLATED
-
+> CONTEXT: Skills/790/message2
+A mass of ice wraps around Abaddon and pulverizes him!#Ron
 > END STRING
 
 > BEGIN STRING
 ヘルハウンド・グラシア
-> CONTEXT: Skills/790/name < UNTRANSLATED
-
+> CONTEXT: Skills/790/name
+Hellhound's Glacier#RonIffy
 > END STRING
 
 > BEGIN STRING
@@ -9673,7 +9673,7 @@ Giddy pleasure swirls through his whole body!!#Ron
 > BEGIN STRING
 吟味の舌技
 > CONTEXT: Skills/837/name
-Probing Tongue Technique#RonLocalisation
+Probing Tongue Technique#RonLocalization
 > END STRING
 
 > BEGIN STRING
@@ -9762,8 +9762,8 @@ Demon Queen's Play#Ron
 
 > BEGIN STRING
 その天使の力を纏った槍は、アバドーンを貫く！
-> CONTEXT: Skills/855/message2 < UNTRANSLATED
-
+> CONTEXT: Skills/855/message2
+Filled with boundless angelic power, it pierces Abaddon!#Ron
 > END STRING
 
 > BEGIN STRING
@@ -9779,14 +9779,14 @@ Deals heavy fire damage to an enemy.#Ron
 
 > BEGIN STRING
 オタク・キャノン
-> CONTEXT: Skills/855/name < UNTRANSLATED
-
+> CONTEXT: Skills/855/name
+Otaku Cannon#Ron
 > END STRING
 
 > BEGIN STRING
 の傍らで、聖騎士サイトウは槍を投擲した！！
-> CONTEXT: Skills/855/message1 < UNTRANSLATED
-
+> CONTEXT: Skills/855/message1
+ watches on as the Holy Knight Saitou hurls his spear!#Ron
 > END STRING
 
 > BEGIN STRING
@@ -10292,7 +10292,7 @@ Sovereign's Insight#Ron
 > BEGIN STRING
 を守るために、夜深は意識を集中した！
 > CONTEXT: Skills/898/message1
-'s defense in mind, Yami centers herself.#RonLocalisation
+'s defense in mind, Yami centers herself.#RonLocalization
 > END STRING
 
 > BEGIN STRING
@@ -10420,7 +10420,7 @@ Prominence#Ron
 > BEGIN STRING
 の傍らで、アリスはプロミネンスを放った！
 > CONTEXT: Skills/905/message1
- hears Alice cast Prominence!#RonLocalisationIffy
+ hears Alice cast Prominence!#RonLocalizationIffy
 > END STRING
 
 > BEGIN STRING
@@ -10447,7 +10447,7 @@ Ice Age#Ron
 > BEGIN STRING
 の傍らで、アリスはアイスエイジを放った！
 > CONTEXT: Skills/906/message1
- hears Alice cast Ice Age!#RonLocalisationIffy
+ hears Alice cast Ice Age!#RonLocalizationIffy
 > END STRING
 
 > BEGIN STRING
@@ -10473,7 +10473,7 @@ Lightning#Ron
 > BEGIN STRING
 の傍らで、アリスはライトニングを放った！
 > CONTEXT: Skills/907/message1
- hears Alice cast Lightning!#RonLocalisation
+ hears Alice cast Lightning!#RonLocalization
 > END STRING
 
 > BEGIN STRING
@@ -10499,7 +10499,7 @@ Delta Aero#Ron
 > BEGIN STRING
 の傍らで、アリスはデルタエアロを放った！
 > CONTEXT: Skills/908/message1
- hears Alice cast Delta Aero!#RonLocalisationIffy
+ hears Alice cast Delta Aero!#RonLocalizationIffy
 > END STRING
 
 > BEGIN STRING
@@ -11035,87 +11035,86 @@ Technique Conversion#Ron
 
 > BEGIN STRING
 全ての者への鎮魂歌
-> CONTEXT: Skills/936/name < UNTRANSLATED
-
+> CONTEXT: Skills/936/name
+Universal Requiem#Ron
 > END STRING
 
 > BEGIN STRING
 は全ての者への鎮魂歌を放った！
-> CONTEXT: Skills/936/message1 < UNTRANSLATED
-> CONTEXT: Skills/937/message1 < UNTRANSLATED
-
+> CONTEXT: Skills/936/message1
+ unleashes Universal Requiem!#Ron
 > END STRING
 
 > BEGIN STRING
 相手の攻撃を防ぐ体勢をとる
-> CONTEXT: Skills/937/description < UNTRANSLATED
-
+> CONTEXT: Skills/937/description
+Braces for an enemy's attack.#Ron
 > END STRING
 
 > BEGIN STRING
 盾
-> CONTEXT: Skills/937/name < UNTRANSLATED
-
+> CONTEXT: Skills/937/name
+Shield#Ron
 > END STRING
 
 > BEGIN STRING
 \\N[1]の全身に力がみなぎる…！
-> CONTEXT: Skills/938/message2 < UNTRANSLATED
-
+> CONTEXT: Skills/938/message2
+\\N[1]'s whole body fills with power!#Ron
 > END STRING
 
 > BEGIN STRING
 四大精霊の加護
-> CONTEXT: Skills/938/name < UNTRANSLATED
-
+> CONTEXT: Skills/938/name
+Protection of The Four Spirits#Ron
 > END STRING
 
 > BEGIN STRING
 に向かって、ルカは精霊たちを喚びだした！
-> CONTEXT: Skills/938/message1 < UNTRANSLATED
-
+> CONTEXT: Skills/938/message1
+ hears Luka invoke the Spirits!#Ron
 > END STRING
 
 > BEGIN STRING
 \\N[1]の前方に、すさまじい魔力が展開される…！！
-> CONTEXT: Skills/939/message2 < UNTRANSLATED
-
+> CONTEXT: Skills/939/message2
+Tremendous magic envelops the area in front of him!!#Ron
 > END STRING
 
 > BEGIN STRING
 魔王の暴虐
-> CONTEXT: Skills/939/name < UNTRANSLATED
-
+> CONTEXT: Skills/939/name
+Monster Lord's Tyranny#Ron
 > END STRING
 
 > BEGIN STRING
 の傍らで、アリスは魔王の暴虐を放った！
-> CONTEXT: Skills/939/message1 < UNTRANSLATED
-
+> CONTEXT: Skills/939/message1
+ watches on as Alice unleashes Monster Lord's Tyranny!#Ron
 > END STRING
 
 > BEGIN STRING
 その逞しい巨漢から繰り出される打撃が、アバドーンに襲いかかる！
 > CONTEXT: Skills/940/message2 < UNTRANSLATED
-
+The burly giant lunges at Abaddon with his attack!#RonIffyWording
 > END STRING
 
 > BEGIN STRING
 胴回し回転蹴り
-> CONTEXT: Skills/940/name < UNTRANSLATED
-
+> CONTEXT: Skills/940/name
+Full Body Roundhouse#Ron
 > END STRING
 
 > BEGIN STRING
 の傍らで、中村は胴回し回転蹴りを放った
-> CONTEXT: Skills/940/message1 < UNTRANSLATED
-
+> CONTEXT: Skills/940/message1
+ watches Nakamura perform a full body roundhouse kick!#RonLocalization
 > END STRING
 
 > BEGIN STRING
 \\C[10]僕と君がここまで来られた理由
-> CONTEXT: Skills/941/description < UNTRANSLATED
-
+> CONTEXT: Skills/941/description
+\\C[10]The reason you and I could come this far.#Ron
 > END STRING
 
 > BEGIN STRING

--- a/Gaijinizer patch/States.txt
+++ b/Gaijinizer patch/States.txt
@@ -2051,14 +2051,14 @@ Ran away#Ron
 
 > BEGIN STRING
 ガードEX
-> CONTEXT: States/246/name < UNTRANSLATED
-
+> CONTEXT: States/246/name
+EX Guard#Ron
 > END STRING
 
 > BEGIN STRING
 は盾で防御した！
 > CONTEXT: States/246/message1
- defends with Shield!#Ron
+ is now in a guarded state!#Ron
 > END STRING
 
 > BEGIN STRING

--- a/Gaijinizer patch/States.txt
+++ b/Gaijinizer patch/States.txt
@@ -2057,14 +2057,14 @@ Ran away#Ron
 
 > BEGIN STRING
 は盾で防御した！
-> CONTEXT: States/246/message1 < UNTRANSLATED
-
+> CONTEXT: States/246/message1
+ defends with Shield!#Ron
 > END STRING
 
 > BEGIN STRING
 は防御体勢を解除した！
-> CONTEXT: States/246/message4 < UNTRANSLATED
-
+> CONTEXT: States/246/message4
+ returns to his normal stance!#Ron
 > END STRING
 
 > BEGIN STRING

--- a/Gaijinizer patch/Troops.txt
+++ b/Gaijinizer patch/Troops.txt
@@ -17628,16 +17628,18 @@ Would you like to read it again?#Ron
 
 > BEGIN STRING
 アバドン
-> CONTEXT: Troops/370/name < UNTRANSLATED
-
+> CONTEXT: Troops/370/name
+Abaddon#Ron
 > END STRING
 
 > BEGIN STRING
 い、意識が…！！
 
 引っ張られる……！！
-> CONTEXT: Troops/370/pages/1/45/Dialogue/ruka_fc1 < UNTRANSLATED
+> CONTEXT: Troops/370/pages/1/45/Dialogue/ruka_fc1
+My consciousness!!
 
+It's being pulled in!!#Ron
 > END STRING
 
 > BEGIN STRING
@@ -17645,8 +17647,11 @@ Would you like to read it again?#Ron
 
 \\C[2]サマエルの『世界を破壊する衝動』を
 キミたちが\\N[1]くんと共有して抑えてるんだ！！
-> CONTEXT: Troops/370/pages/1/49/Dialogue/enemy29 < UNTRANSLATED
+> CONTEXT: Troops/370/pages/1/49/Dialogue/enemy29
+Endure it, you two!!
 
+\\C[2]You're both holding back Samael's world-destroying
+impulses with \\N[1]-kun!!#Ron
 > END STRING
 
 > BEGIN STRING
@@ -17654,8 +17659,10 @@ Would you like to read it again?#Ron
 \\N[1]くんは自身のコントロールを失ってしまう！！
 
 本当の意味での\\C[10]全ての破壊者\\C[2]になってしまうんだ！！
-> CONTEXT: Troops/370/pages/1/54/Dialogue/enemy29 < UNTRANSLATED
-
+> CONTEXT: Troops/370/pages/1/54/Dialogue/enemy29
+\\C[2]He'll lose control if either of you lose
+consciousness!! That'll turn him into a destroyer
+of \\C[10]literally everything\\C[0]!!#Ron
 > END STRING
 
 > BEGIN STRING
@@ -17663,36 +17670,42 @@ Would you like to read it again?#Ron
 思った以上に、精神を集中しないとダメだ……
 
 \\C[2]攻撃は、\\N[1]に任せるしかないか……！
-> CONTEXT: Troops/370/pages/1/59/Dialogue/ruka_fc1 < UNTRANSLATED
-
+> CONTEXT: Troops/370/pages/1/59/Dialogue/ruka_fc1
+Kgh... focusing my mind is a lot more important
+than I thought I'd be. \\C[2]We'll have to leave all
+the fighting to \\N[1]!#Ron
 > END STRING
 
 > BEGIN STRING
 なぁにがサマえルだぁぁぁぁぁ
 
 まだぐっでやるう”ううううぅぅぅ
-> CONTEXT: Troops/370/pages/3/5/Dialogue/enemy40 < UNTRANSLATED
+> CONTEXT: Troops/370/pages/3/5/Dialogue/enemy40
+WHAT ARE YOU, SAMAAAAAAAEL...
 
+I'LL DEVOUR YOOOOOOOOOOOU...#Ron
 > END STRING
 
 > BEGIN STRING
 ごりごりにがみぐだいでえええええ
 
 とりこんでやるう"う"う"う"う"""う"
-> CONTEXT: Troops/370/pages/3/9/Dialogue/enemy40 < UNTRANSLATED
+> CONTEXT: Troops/370/pages/3/9/Dialogue/enemy40
+I'LL CRUSH YOU IN MY JAAAAWS...
 
+GET IN MY MOUUUU\\X[15]UUUUTH\\X[0]...#Ron
 > END STRING
 
 > BEGIN STRING
 させないっ！！！！！！
-> CONTEXT: Troops/370/pages/3/14/Dialogue/enemy30 < UNTRANSLATED
-
+> CONTEXT: Troops/370/pages/3/14/Dialogue/enemy30
+Oh no you don't!!!#Ron
 > END STRING
 
 > BEGIN STRING
 ごああああああああああああああああああああ
-> CONTEXT: Troops/370/pages/3/26/Dialogue/enemy40 < UNTRANSLATED
-
+> CONTEXT: Troops/370/pages/3/26/Dialogue/enemy40
+GOAAAAAAAAAAAAAAARGH...#Ron
 > END STRING
 
 > BEGIN STRING
@@ -17700,57 +17713,73 @@ Would you like to read it again?#Ron
 もう少しでアバドーンの懐に入り込めるよ！！
 
 がんばって！！！！！
-> CONTEXT: Troops/370/pages/3/28/Dialogue/enemy15 < UNTRANSLATED
+> CONTEXT: Troops/370/pages/3/28/Dialogue/enemy15
+You're almost there, \\N[1]-kun!!
 
+Keep fighting!! You can do it!!!!#Ron
 > END STRING
 
 > BEGIN STRING
 きっとキミなら、みんなを救える！！
 
 自信を持って！！！がんばって！！！
-> CONTEXT: Troops/370/pages/3/33/Dialogue/enemy15 < UNTRANSLATED
+> CONTEXT: Troops/370/pages/3/33/Dialogue/enemy15
+You'll definitely save everyone!!
 
+I believe in you!! Do your best!!#Ron
 > END STRING
 
 > BEGIN STRING
 さぁ………
 
 私もとっておきの攻撃、いくよっ！！！
-> CONTEXT: Troops/370/pages/3/38/Dialogue/enemy30 < UNTRANSLATED
+> CONTEXT: Troops/370/pages/3/38/Dialogue/enemy30
+Now then...
 
+Time for me to use my own trump card, here I go!!#Ron
 > END STRING
 
 > BEGIN STRING
 アバドーンは大きく息を吸い込んでいる……
 
 \\C[2]何か仕掛けてくる気だ……！
-> CONTEXT: Troops/370/pages/3/57/Dialogue < UNTRANSLATED
-> CONTEXT: Troops/370/pages/4/10/Dialogue < UNTRANSLATED
+> CONTEXT: Troops/370/pages/3/57/Dialogue
+> CONTEXT: Troops/370/pages/4/10/Dialogue
+Abaddon takes a deep breath...
 
+\\C[2]It looks like he's about to do something!#Ron
 > END STRING
 
 > BEGIN STRING
 やれやれ………
 
 また\\C[2]この銃\\C[0]のお世話になる日が来るとはね……
-> CONTEXT: Troops/370/pages/3/65/Dialogue/enemy38 < UNTRANSLATED
+> CONTEXT: Troops/370/pages/3/65/Dialogue/enemy38
+Good grief...
 
+I didn't think the day would come again when I'd
+have to rely on \\C[2]this gun\\C[0].#Ron
 > END STRING
 
 > BEGIN STRING
 \\C[2]『メギドフレイム』\\C[0]………
 
 魔女帝リリスを倒す足がかりとなった武器……
-> CONTEXT: Troops/370/pages/3/69/Dialogue/enemy37 < UNTRANSLATED
+> CONTEXT: Troops/370/pages/3/69/Dialogue/enemy37
+\\C[2]Megido Flame\\C[0]...
 
+The weapon you used as a stepping stone to defeat
+the Witch Empress Lilith...#Ron
 > END STRING
 
 > BEGIN STRING
 ミズキ、ソレ使ウト、死ヌホドヨワル
 
 マタ、魔界洛ニオチルカ？
-> CONTEXT: Troops/370/pages/3/73/Dialogue/enemy37 < UNTRANSLATED
+> CONTEXT: Troops/370/pages/3/73/Dialogue/enemy37
+YOU USE THAT, YOU GET DEATHLY WEAK...
 
+YOU GONNA FALL INTO DEMON REALM CAPITAL AGAIN?#Ron
 > END STRING
 
 > BEGIN STRING
@@ -17758,92 +17787,114 @@ Would you like to read it again?#Ron
 
 その代わり、アンタたちにも全力で働いてもらうから！！
 準備はいい、２人とも！？
-> CONTEXT: Troops/370/pages/3/77/Dialogue/enemy38 < UNTRANSLATED
+> CONTEXT: Troops/370/pages/3/77/Dialogue/enemy38
+No way, I'll control it.
 
+But I'll need you two to put your full power into
+this for me!! Are you ready?!#Ron
 > END STRING
 
 > BEGIN STRING
 無論だ。
 
 我らが力、存分に振るえ！ミズキ！！
-> CONTEXT: Troops/370/pages/3/82/Dialogue/enemy37 < UNTRANSLATED
+> CONTEXT: Troops/370/pages/3/82/Dialogue/enemy37
+Of course.
 
+Wield our power to the fullest, Mizuki!!#Ron
 > END STRING
 
 > BEGIN STRING
 ヤット、出番！！
 
 アオオオオオオオオンン！！！！！！！！！
-> CONTEXT: Troops/370/pages/3/86/Dialogue/enemy37 < UNTRANSLATED
+> CONTEXT: Troops/370/pages/3/86/Dialogue/enemy37
+FINALLY OUR TURN!!
 
+AWOOOOOOOOOOOOOOOOON!!!!#Ron
 > END STRING
 
 > BEGIN STRING
 もらった！！！！！！！！！！
 
 これでも喰らえっ！！！
-> CONTEXT: Troops/370/pages/3/96/Dialogue/enemy38 < UNTRANSLATED
+> CONTEXT: Troops/370/pages/3/96/Dialogue/enemy38
+It's ready!!
 
+Eat this!!!!!#Ron
 > END STRING
 
 > BEGIN STRING
 きさまらああああああああああああああ
 
 じゃばをずらばあああああああああああああ
-> CONTEXT: Troops/370/pages/3/111/Dialogue/enemy40 < UNTRANSLATED
+> CONTEXT: Troops/370/pages/3/111/Dialogue/enemy40
+YOU WOOOOOOOOOOOOORMS...
 
+STAY OUT OF MY WAAAAAAAAAAAAAY...#Ron
 > END STRING
 
 > BEGIN STRING
 我のこの肉体は、飾りではないぞ。
 
 貴様の攻撃を受け止め、反撃することくらいは容易い……
-> CONTEXT: Troops/370/pages/3/123/Dialogue/enemy35 < UNTRANSLATED
+> CONTEXT: Troops/370/pages/3/123/Dialogue/enemy35
+My physique isn't just for show...
 
+Taking your attack and striking back will be
+child's play.#Ron
 > END STRING
 
 > BEGIN STRING
 天使長たるこの中村の体技
 
 しかとその身に刻め！！
-> CONTEXT: Troops/370/pages/3/127/Dialogue/enemy35 < UNTRANSLATED
-
+> CONTEXT: Troops/370/pages/3/127/Dialogue/enemy35
+I, Chief Angel Nakamura, will thoroughly etch the
+proof of my martial prowess upon your body!!#RonLocalization
 > END STRING
 
 > BEGIN STRING
 おお………\\C[2]聖騎士サイトウ…！！
 
 子孫マリオンの意志に呼応し、英霊として現れ出でたか！！
-> CONTEXT: Troops/370/pages/3/146/Dialogue/enemy35 < UNTRANSLATED
+> CONTEXT: Troops/370/pages/3/146/Dialogue/enemy35
+Oooh, \\C[2]it's the Holy Knight Saitou!!
 
+Have you appeared as a heroic spirit in response
+to the determination of your descendant, Marion?!#RonLocalization
 > END STRING
 
 > BEGIN STRING
 あああああああああああああああぁぁぁぁぁ！！！
-> CONTEXT: Troops/370/pages/3/156/Dialogue/enemy40 < UNTRANSLATED
-
+> CONTEXT: Troops/370/pages/3/156/Dialogue/enemy40
+AAAAAAAAAAAAAAAAAaaaah!!!#Ron
 > END STRING
 
 > BEGIN STRING
 ………ッ！！！
-> CONTEXT: Troops/370/pages/3/159/Dialogue/ruka_fc1 < UNTRANSLATED
-
+> CONTEXT: Troops/370/pages/3/159/Dialogue/ruka_fc1
+...Gh!!!#Ron
 > END STRING
 
 > BEGIN STRING
 させるか！！！！！！！！！
 
 これでも喰らえ！！！
-> CONTEXT: Troops/370/pages/3/164/Dialogue/alice_fc6 < UNTRANSLATED
+> CONTEXT: Troops/370/pages/3/164/Dialogue/alice_fc6
+Not on my watch!!!!
 
+Take this!!#Ron
 > END STRING
 
 > BEGIN STRING
 精霊のみんな、お願いだ……！
 
 僕の代わりに、\\N[1]を……！
-> CONTEXT: Troops/370/pages/3/176/Dialogue/ruka_fc1 < UNTRANSLATED
+> CONTEXT: Troops/370/pages/3/176/Dialogue/ruka_fc1
+Spirits, hear my call!
 
+Give \\N[1] your blessings instead of me!#Ron
 > END STRING
 
 > BEGIN STRING


### PR DESCRIPTION
This commit contains the following:

* The final Abaddon fight including all the cut-ins
* All the skills used during that fight
* Removal of the extra line linking the Universal Requiem usage text to the Shield skill
* All of the scenes after defeating Abaddon up until the next checkpoint save in the multiverse
* A fix-up for a mistake I noticed on a couple of Daji's skills
* Fixing up some old attributions

None of the plugin files are included with this PR.